### PR TITLE
Changed GeneratorStage to be a class instead of an enum.

### DIFF
--- a/src/main/java/cubicchunks/CustomCubicChunksWorldType.java
+++ b/src/main/java/cubicchunks/CustomCubicChunksWorldType.java
@@ -42,12 +42,19 @@ public class CustomCubicChunksWorldType extends WorldType implements ICubicChunk
 
 	@Override public void registerWorldGen(ICubicWorldServer world, GeneratorPipeline pipeline) {
 		ServerCubeCache cubeCache = world.getCubeCache();
+		
 		// init the worldgen pipeline
-		pipeline.addStage(GeneratorStage.TERRAIN, new CustomTerrainProcessor(world, 5));
-		pipeline.addStage(GeneratorStage.SURFACE, new CustomSurfaceProcessor(cubeCache, 10, world.getSeed()));
-		pipeline.addStage(GeneratorStage.FEATURES, new CustomFeatureProcessor("Features", cubeCache, 10));
-		pipeline.addStage(GeneratorStage.LIGHTING, new FirstLightProcessor("Lighting", cubeCache, 5));
-		pipeline.addStage(GeneratorStage.POPULATION, new CustomPopulationProcessor("Population", world, 100));
+		GeneratorStage terrain = new GeneratorStage("terrain");
+		GeneratorStage surface = new GeneratorStage("surface");
+		GeneratorStage features = new GeneratorStage("features");
+		GeneratorStage lighting = new GeneratorStage("lighting");
+		GeneratorStage population = new GeneratorStage("population");		
+		
+		pipeline.addStage(terrain, new CustomTerrainProcessor(world, 5));
+		pipeline.addStage(surface, new CustomSurfaceProcessor(surface, cubeCache, 10, world.getSeed()));
+		pipeline.addStage(features, new CustomFeatureProcessor(features, "Features", cubeCache, 10));
+		pipeline.addStage(lighting, new FirstLightProcessor(lighting, "Lighting", cubeCache, 5));
+		pipeline.addStage(population, new CustomPopulationProcessor(population, "Population", world, 100));
 	}
 
 	public static void create() {

--- a/src/main/java/cubicchunks/CustomCubicChunksWorldType.java
+++ b/src/main/java/cubicchunks/CustomCubicChunksWorldType.java
@@ -47,13 +47,12 @@ public class CustomCubicChunksWorldType extends WorldType implements ICubicChunk
 		GeneratorStage terrain = new GeneratorStage("terrain");
 		GeneratorStage surface = new GeneratorStage("surface");
 		GeneratorStage features = new GeneratorStage("features");
-		GeneratorStage lighting = new GeneratorStage("lighting");
 		GeneratorStage population = new GeneratorStage("population");		
 		
 		pipeline.addStage(terrain, new CustomTerrainProcessor(world, 5));
 		pipeline.addStage(surface, new CustomSurfaceProcessor(surface, cubeCache, 10, world.getSeed()));
 		pipeline.addStage(features, new CustomFeatureProcessor(features, "Features", cubeCache, 10));
-		pipeline.addStage(lighting, new FirstLightProcessor(lighting, "Lighting", cubeCache, 5));
+		pipeline.addStage(GeneratorStage.LIGHTING, new FirstLightProcessor(GeneratorStage.LIGHTING, "Lighting", cubeCache, 5));
 		pipeline.addStage(population, new CustomPopulationProcessor(population, "Population", world, 100));
 	}
 

--- a/src/main/java/cubicchunks/FlatCubicChunksWorldType.java
+++ b/src/main/java/cubicchunks/FlatCubicChunksWorldType.java
@@ -41,11 +41,10 @@ public class FlatCubicChunksWorldType extends WorldType implements ICubicChunksW
 	@Override public void registerWorldGen(ICubicWorldServer world, GeneratorPipeline pipeline) {
 		ServerCubeCache cubeCache = world.getCubeCache();
 		// init the worldgen pipeline
-		pipeline.addStage(GeneratorStage.TERRAIN, new FlatTerrainProcessor(cubeCache, 5));
-		pipeline.addStage(GeneratorStage.SURFACE, new NullProcessor("Surface", cubeCache));
-		pipeline.addStage(GeneratorStage.FEATURES, new NullProcessor("Features", cubeCache));
+		GeneratorStage terrain = new GeneratorStage("terrain");
+		
+		pipeline.addStage(terrain, new FlatTerrainProcessor(cubeCache, 5));
 		pipeline.addStage(GeneratorStage.LIGHTING, new FirstLightProcessor(null, "Lighting", cubeCache, 5));
-		pipeline.addStage(GeneratorStage.POPULATION, new NullProcessor("Population", cubeCache));
 	}
 
 	public static void create() {

--- a/src/main/java/cubicchunks/FlatCubicChunksWorldType.java
+++ b/src/main/java/cubicchunks/FlatCubicChunksWorldType.java
@@ -44,7 +44,7 @@ public class FlatCubicChunksWorldType extends WorldType implements ICubicChunksW
 		pipeline.addStage(GeneratorStage.TERRAIN, new FlatTerrainProcessor(cubeCache, 5));
 		pipeline.addStage(GeneratorStage.SURFACE, new NullProcessor("Surface", cubeCache));
 		pipeline.addStage(GeneratorStage.FEATURES, new NullProcessor("Features", cubeCache));
-		pipeline.addStage(GeneratorStage.LIGHTING, new FirstLightProcessor("Lighting", cubeCache, 5));
+		pipeline.addStage(GeneratorStage.LIGHTING, new FirstLightProcessor(null, "Lighting", cubeCache, 5));
 		pipeline.addStage(GeneratorStage.POPULATION, new NullProcessor("Population", cubeCache));
 	}
 

--- a/src/main/java/cubicchunks/VanillaCubicChunksWorldType.java
+++ b/src/main/java/cubicchunks/VanillaCubicChunksWorldType.java
@@ -45,12 +45,19 @@ public class VanillaCubicChunksWorldType extends WorldType implements ICubicChun
 		ServerCubeCache cubeCache = world.getCubeCache();
 
 		ChunkProviderOverworld vanillaGen = new ChunkProviderOverworld((World) world, world.getSeed(), true, "");
+		
 		// init the worldgen pipeline
-		pipeline.addStage(GeneratorStage.TERRAIN, new VanillaTerrainProcessor(world, vanillaGen, 5));
-		pipeline.addStage(GeneratorStage.SURFACE, new NullProcessor("Surface", cubeCache));
-		pipeline.addStage(GeneratorStage.FEATURES, new NullProcessor("Features", cubeCache));
-		pipeline.addStage(GeneratorStage.LIGHTING, new FirstLightProcessor("Lighting", cubeCache, 5));
-		pipeline.addStage(GeneratorStage.POPULATION, new VanillaPopulationProcessor(world, vanillaGen, 5));
+		GeneratorStage terrain = new GeneratorStage("terrain");
+		GeneratorStage surface = new GeneratorStage("surface");
+		GeneratorStage features = new GeneratorStage("features");
+		GeneratorStage lighting = new GeneratorStage("lighting");
+		GeneratorStage population = new GeneratorStage("population");		
+		
+		pipeline.addStage(terrain, new VanillaTerrainProcessor(surface, world, vanillaGen, 5));
+		pipeline.addStage(surface, new NullProcessor("Surface", cubeCache));
+		pipeline.addStage(features, new NullProcessor("Features", cubeCache));
+		pipeline.addStage(GeneratorStage.LIGHTING, new FirstLightProcessor(GeneratorStage.LIGHTING, "Lighting", cubeCache, 5));
+		pipeline.addStage(population, new VanillaPopulationProcessor(population, world, vanillaGen, 5));
 
 	}
 

--- a/src/main/java/cubicchunks/VanillaCubicChunksWorldType.java
+++ b/src/main/java/cubicchunks/VanillaCubicChunksWorldType.java
@@ -49,13 +49,9 @@ public class VanillaCubicChunksWorldType extends WorldType implements ICubicChun
 		// init the worldgen pipeline
 		GeneratorStage terrain = new GeneratorStage("terrain");
 		GeneratorStage surface = new GeneratorStage("surface");
-		GeneratorStage features = new GeneratorStage("features");
-		GeneratorStage lighting = new GeneratorStage("lighting");
 		GeneratorStage population = new GeneratorStage("population");		
 		
 		pipeline.addStage(terrain, new VanillaTerrainProcessor(surface, world, vanillaGen, 5));
-		pipeline.addStage(surface, new NullProcessor("Surface", cubeCache));
-		pipeline.addStage(features, new NullProcessor("Features", cubeCache));
 		pipeline.addStage(GeneratorStage.LIGHTING, new FirstLightProcessor(GeneratorStage.LIGHTING, "Lighting", cubeCache, 5));
 		pipeline.addStage(population, new VanillaPopulationProcessor(population, world, vanillaGen, 5));
 

--- a/src/main/java/cubicchunks/asm/mixin/core/MixinWorld.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/MixinWorld.java
@@ -215,7 +215,7 @@ public abstract class MixinWorld implements ICubicWorld {
 					}
 					Column column = cube.getColumn();
 					if ((!allowEmptyColumns && column instanceof BlankColumn)
-							|| (minStageAllowed != null && cube.getGeneratorStage().isLessThan(minStageAllowed))) {
+							|| (minStageAllowed != null && cube.getGeneratorStage().precedes(minStageAllowed))) {
 						return false;
 					}
 				}

--- a/src/main/java/cubicchunks/client/ClientCubeCache.java
+++ b/src/main/java/cubicchunks/client/ClientCubeCache.java
@@ -123,7 +123,7 @@ public class ClientCubeCache extends ChunkProviderClient implements ICubeCache {
 		}
 
 		// cubes are always live on the client
-		cube.setGeneratorStage(GeneratorStage.getLastStage());
+		cube.setGeneratorStage(GeneratorStage.LIVE);
 
 		return cube;
 	}

--- a/src/main/java/cubicchunks/lighting/FirstLightProcessor.java
+++ b/src/main/java/cubicchunks/lighting/FirstLightProcessor.java
@@ -61,8 +61,11 @@ public class FirstLightProcessor extends CubeProcessor {
 	//mutableBlockPos variable to avoid creating thousands of instances of BlockPos
 	private BlockPos.MutableBlockPos mutablePos = new BlockPos.MutableBlockPos();
 
-	public FirstLightProcessor(String name, ICubeCache cache, int batchSize) {
+	private GeneratorStage generatorStage;
+	
+	public FirstLightProcessor(GeneratorStage lighting, String name, ICubeCache cache, int batchSize) {
 		super(name, cache, batchSize);
+		this.generatorStage = lighting;
 	}
 
 	@Override
@@ -307,6 +310,6 @@ public class FirstLightProcessor extends CubeProcessor {
 		final int totalRadius = lightUpdateRadius + cubeSizeRadius + bufferRadius;
 
 		// only continue if the neighboring cubes are at least in the lighting stage
-		return cube.getWorld().blocksExist(cubeCenter, totalRadius, false, GeneratorStage.LIGHTING);
+		return cube.getWorld().blocksExist(cubeCenter, totalRadius, false, generatorStage);
 	}
 }

--- a/src/main/java/cubicchunks/lighting/LightingManager.java
+++ b/src/main/java/cubicchunks/lighting/LightingManager.java
@@ -28,6 +28,7 @@ import cubicchunks.util.Coords;
 import cubicchunks.world.ICubicWorld;
 import cubicchunks.world.column.Column;
 import cubicchunks.world.cube.Cube;
+import cubicchunks.worldgen.GeneratorStage;
 
 import java.util.Set;
 
@@ -46,7 +47,7 @@ public class LightingManager {
 
 		this.skylightCubeDiffuseProcessor = new SkyLightCubeDiffuseProcessor(world, "Sky Light Diffuse", 5);
 
-		this.firstLightProcessor = new FirstLightProcessor(null, "First Light", world.getCubeCache(), 1);
+		this.firstLightProcessor = new FirstLightProcessor(GeneratorStage.LIGHTING, "First Light", world.getCubeCache(), 1);
 	}
 
 	public void columnSkylightUpdate(UpdateType type, Column column, int localX, int minY, int maxY, int localZ) {

--- a/src/main/java/cubicchunks/lighting/LightingManager.java
+++ b/src/main/java/cubicchunks/lighting/LightingManager.java
@@ -46,7 +46,7 @@ public class LightingManager {
 
 		this.skylightCubeDiffuseProcessor = new SkyLightCubeDiffuseProcessor(world, "Sky Light Diffuse", 5);
 
-		this.firstLightProcessor = new FirstLightProcessor("First Light", world.getCubeCache(), 1);
+		this.firstLightProcessor = new FirstLightProcessor(null, "First Light", world.getCubeCache(), 1);
 	}
 
 	public void columnSkylightUpdate(UpdateType type, Column column, int localX, int minY, int maxY, int localZ) {

--- a/src/main/java/cubicchunks/network/WorldEncoder.java
+++ b/src/main/java/cubicchunks/network/WorldEncoder.java
@@ -76,7 +76,7 @@ public class WorldEncoder {
 
 	public static void decodeCube(PacketBuffer in, Cube cube) throws IOException {
 		// if the cube came from the server, it must be live
-		cube.setGeneratorStage(GeneratorStage.getLastStage());
+		cube.setGeneratorStage(GeneratorStage.LIVE);
 
 		// 1. emptiness
 		boolean isEmpty = in.readBoolean();

--- a/src/main/java/cubicchunks/server/CubeIO.java
+++ b/src/main/java/cubicchunks/server/CubeIO.java
@@ -29,6 +29,7 @@ import cubicchunks.util.ConcurrentBatchedQueue;
 import cubicchunks.util.Coords;
 import cubicchunks.world.ChunkSectionHelper;
 import cubicchunks.world.ICubicWorld;
+import cubicchunks.world.ICubicWorldServer;
 import cubicchunks.world.OpacityIndex;
 import cubicchunks.world.column.Column;
 import cubicchunks.world.cube.Cube;
@@ -100,7 +101,7 @@ public class CubeIO implements IThreadedFileIO {
 		// see: http://www.mapdb.org/features.html
 	}
 
-	private ICubicWorld world;
+	private ICubicWorldServer world;
 
 	private final DB db;
 	private ConcurrentNavigableMap<Long, byte[]> columns;
@@ -110,7 +111,7 @@ public class CubeIO implements IThreadedFileIO {
 
 	private final Thread theShutdownHook;
 
-	public CubeIO(ICubicWorld world) {
+	public CubeIO(ICubicWorldServer world) {
 		this.world = world;
 
 		this.db = initializeDBConnection(this.world.getSaveHandler().getWorldDirectory(), this.world.getProvider());
@@ -363,7 +364,7 @@ public class CubeIO implements IThreadedFileIO {
 		final Cube cube = column.getOrCreateCube(cubeY, false);
 
 		// get the worldgen stage
-		cube.setGeneratorStage(GeneratorStage.values()[nbt.getByte("GeneratorStage")]);
+		cube.setGeneratorStage(this.world.getGeneratorPipeline().getStage(nbt.getString("GeneratorStage")));
 
 		// is this an empty cube?
 		boolean isEmpty = !nbt.hasKey("Blocks");
@@ -490,7 +491,7 @@ public class CubeIO implements IThreadedFileIO {
 		nbt.setInteger("y", cube.getY());
 		nbt.setInteger("z", cube.getZ());
 
-		nbt.setByte("GeneratorStage", (byte) cube.getGeneratorStage().ordinal());
+		nbt.setString("GeneratorStage", cube.getGeneratorStage().getName());
 
 		if (!cube.isEmpty()) {
 

--- a/src/main/java/cubicchunks/server/ServerCubeCache.java
+++ b/src/main/java/cubicchunks/server/ServerCubeCache.java
@@ -341,7 +341,7 @@ public class ServerCubeCache extends ChunkProviderServer implements ICubeCache {
 		if (loadType == LOAD_OR_GENERATE && cube == null) {
 			// start the cube generation process with an empty cube
 			cube = column.getOrCreateCube(cubeY, true);
-			cube.setGeneratorStage(GeneratorStage.getFirstStage());
+			cube.setGeneratorStage(this.worldServer.getGeneratorPipeline().getFirstStage());
 		}
 		//if couldn't generate it - return
 		if (cube == null) {
@@ -423,7 +423,7 @@ public class ServerCubeCache extends ChunkProviderServer implements ICubeCache {
 		addForcedByMapping(forcedBy, cube);
 		//set generator stage, technically shouldn't be needed because it's set in worldgen code
 		//but in case not all cubes are saved - it would crash.
-		cube.setGeneratorStage(GeneratorStage.TERRAIN);
+		cube.setGeneratorStage(this.worldServer.getGeneratorPipeline().getFirstStage());
 		return cube;
 	}
 

--- a/src/main/java/cubicchunks/worldgen/GeneratorStage.java
+++ b/src/main/java/cubicchunks/worldgen/GeneratorStage.java
@@ -25,11 +25,7 @@ package cubicchunks.worldgen;
 
 public class GeneratorStage {
 	
-	public static GeneratorStage TERRAIN = new GeneratorStage("terrain");
-	public static GeneratorStage SURFACE = new GeneratorStage("surface");
-	public static GeneratorStage FEATURES = new GeneratorStage("features");
 	public static GeneratorStage LIGHTING = new GeneratorStage("lighting");
-	public static GeneratorStage POPULATION = new GeneratorStage("population");
 	
 	public static GeneratorStage LIVE = new GeneratorStage("live");
 	static {

--- a/src/main/java/cubicchunks/worldgen/GeneratorStage.java
+++ b/src/main/java/cubicchunks/worldgen/GeneratorStage.java
@@ -21,6 +21,7 @@
  *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  *  THE SOFTWARE.
  */
+
 package cubicchunks.worldgen;
 
 public class GeneratorStage {

--- a/src/main/java/cubicchunks/worldgen/GeneratorStage.java
+++ b/src/main/java/cubicchunks/worldgen/GeneratorStage.java
@@ -72,11 +72,11 @@ public class GeneratorStage {
 	}
 	
 	
-	public void setOrdinal(int ordinal) {
+	void setOrdinal(int ordinal) {
 		this.ordinal = ordinal;
 	}
 	
-	public int getOrdinal() {
+	int getOrdinal() {
 		return this.ordinal;
 	}
 

--- a/src/main/java/cubicchunks/worldgen/GeneratorStage.java
+++ b/src/main/java/cubicchunks/worldgen/GeneratorStage.java
@@ -23,27 +23,67 @@
  */
 package cubicchunks.worldgen;
 
-public enum GeneratorStage {
-	TERRAIN,
-	SURFACE,
-	FEATURES,
-	LIGHTING,
-	POPULATION,
-	LIVE;
-
-	public static GeneratorStage getFirstStage() {
-		return values()[0];
+public class GeneratorStage {
+	
+	public static GeneratorStage TERRAIN = new GeneratorStage("terrain");
+	public static GeneratorStage SURFACE = new GeneratorStage("surface");
+	public static GeneratorStage FEATURES = new GeneratorStage("features");
+	public static GeneratorStage LIGHTING = new GeneratorStage("lighting");
+	public static GeneratorStage POPULATION = new GeneratorStage("population");
+	
+	public static GeneratorStage LIVE = new GeneratorStage("live");
+	static {
+		LIVE.setLastStage();
+		LIVE.setOrdinal(Integer.MAX_VALUE);
 	}
-
-	public static GeneratorStage getLastStage() {
-		return values()[values().length - 1];
+	
+	private final String name;
+	
+	private boolean isLast;
+	
+	private int ordinal;
+	
+	private StageProcessor processor;
+	
+		
+	public GeneratorStage(String name) {
+		this.name = name;
+		this.isLast = false;
+	}
+	
+	
+	public String getName() {
+		return this.name;
+	}
+	
+	
+	public void setLastStage() {
+		this.isLast = true;
 	}
 
 	public boolean isLastStage() {
-		return ordinal() == values().length - 1;
+		return this.isLast;
+	}
+	
+	
+	public void setProcessor(StageProcessor processor) {
+		this.processor = processor;
 	}
 
-	public boolean isLessThan(GeneratorStage other) {
-		return ordinal() < other.ordinal();
+	public StageProcessor getProcessor() {
+		return this.processor;
+	}
+	
+	
+	public void setOrdinal(int ordinal) {
+		this.ordinal = ordinal;
+	}
+	
+	public int getOrdinal() {
+		return this.ordinal;
+	}
+
+	public boolean precedes(GeneratorStage other) {
+		return this.ordinal < other.ordinal;
 	}
 }

--- a/src/main/java/cubicchunks/worldgen/StageProcessor.java
+++ b/src/main/java/cubicchunks/worldgen/StageProcessor.java
@@ -1,3 +1,27 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
 package cubicchunks.worldgen;
 
 import cubicchunks.util.processor.QueueProcessor;

--- a/src/main/java/cubicchunks/worldgen/StageProcessor.java
+++ b/src/main/java/cubicchunks/worldgen/StageProcessor.java
@@ -1,0 +1,14 @@
+package cubicchunks.worldgen;
+
+import cubicchunks.util.processor.QueueProcessor;
+
+public class StageProcessor {
+
+	public QueueProcessor<Long> processor;
+	public float share;
+
+	public StageProcessor(QueueProcessor<Long> processor) {
+		this.processor = processor;
+		this.share = 0f;
+	}
+}

--- a/src/main/java/cubicchunks/worldgen/generator/custom/CustomFeatureProcessor.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/CustomFeatureProcessor.java
@@ -42,6 +42,7 @@ import java.util.Set;
 @SuppressWarnings("unused")
 public class CustomFeatureProcessor extends CubeProcessor {
 
+	private GeneratorStage generatorStage;
 	private CubicCaveGenerator caveGenerator;
 	private MapGenStronghold strongholdGenerator;
 	private MapGenVillage villageGenerator;
@@ -51,9 +52,10 @@ public class CustomFeatureProcessor extends CubeProcessor {
 
 	private ICubicWorld worldObj;
 
-	public CustomFeatureProcessor(String name, ICubeCache provider, int batchSize) {
+	public CustomFeatureProcessor(GeneratorStage generatorStage, String name, ICubeCache provider, int batchSize) {
 		super(name, provider, batchSize);
-
+		
+		this.generatorStage = generatorStage;
 		this.caveGenerator = new CubicCaveGenerator();
 		this.strongholdGenerator = new MapGenStronghold();
 		this.villageGenerator = new MapGenVillage();
@@ -99,6 +101,6 @@ public class CustomFeatureProcessor extends CubeProcessor {
 			return false;
 		}
 		Cube below = this.cache.getCube(cubeX, cubeY, cubeZ);
-		return !below.getGeneratorStage().isLessThan(GeneratorStage.FEATURES);
+		return !below.getGeneratorStage().precedes(generatorStage);
 	}
 }

--- a/src/main/java/cubicchunks/worldgen/generator/custom/CustomPopulationProcessor.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/CustomPopulationProcessor.java
@@ -41,11 +41,13 @@ import java.util.Set;
 
 public class CustomPopulationProcessor extends CubeProcessor {
 
+	private GeneratorStage generatorStage;
 	private Map<Biome, BiomeFeatures> biomeFeaturesMap;
 
-	public CustomPopulationProcessor(String name, ICubicWorld world, int batchSize) {
+	public CustomPopulationProcessor(GeneratorStage generatorStage, String name, ICubicWorld world, int batchSize) {
 		super(name, world.getCubeCache(), batchSize);
 
+		this.generatorStage = generatorStage;
 		this.biomeFeaturesMap = new HashMap<>();
 
 		// for now use global for all biomes
@@ -60,7 +62,7 @@ public class CustomPopulationProcessor extends CubeProcessor {
 	@Override
 	public Set<Cube> calculate(Cube cube) {
 		if (true) return Sets.newHashSet(cube);
-		if (!cube.getWorld().cubeAndNeighborsExist(cube, true, GeneratorStage.POPULATION)) {
+		if (!cube.getWorld().cubeAndNeighborsExist(cube, true, generatorStage)) {
 			return Collections.EMPTY_SET;
 		}
 

--- a/src/main/java/cubicchunks/worldgen/generator/custom/CustomSurfaceProcessor.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/CustomSurfaceProcessor.java
@@ -41,13 +41,14 @@ public class CustomSurfaceProcessor extends CubeProcessor {
 
 	private static final String PROCESSOR_NAME = "Surface";
 
+	private GeneratorStage generatorStage;
 	private Random rand;
 	private NoiseGeneratorMultiFractal noiseGen;
 	private double[] noise;
 	private Biome[] biomes;
-	private long seed;
+	private long seed; 
 
-	public CustomSurfaceProcessor(final ICubeCache cubeCache, final int batchSize, final long seed) {
+	public CustomSurfaceProcessor(GeneratorStage generatorStage, final ICubeCache cubeCache, final int batchSize, final long seed) {
 		super(PROCESSOR_NAME, cubeCache, batchSize);
 		this.rand = new Random(seed);
 		this.noiseGen = new NoiseGeneratorMultiFractal(this.rand, 4);
@@ -122,6 +123,6 @@ public class CustomSurfaceProcessor extends CubeProcessor {
 			return false;
 		}
 		Cube above = this.cache.getCube(cubeX, cubeY, cubeZ);
-		return !above.getGeneratorStage().isLessThan(GeneratorStage.SURFACE);
+		return !above.getGeneratorStage().precedes(generatorStage);
 	}
 }

--- a/src/main/java/cubicchunks/worldgen/generator/vanilla/VanillaPopulationProcessor.java
+++ b/src/main/java/cubicchunks/worldgen/generator/vanilla/VanillaPopulationProcessor.java
@@ -36,12 +36,15 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class VanillaPopulationProcessor extends CubeProcessor {
+	
+	private GeneratorStage generatorStage;
 	private ServerCubeCache provider;
 	private ICubicWorldServer world;
 	private ChunkProviderOverworld vanillaGen;
 
-	public VanillaPopulationProcessor(ICubicWorldServer world, ChunkProviderOverworld vanillaGen, int batchSize) {
+	public VanillaPopulationProcessor(GeneratorStage generatorStage, ICubicWorldServer world, ChunkProviderOverworld vanillaGen, int batchSize) {
 		super("Population", world.getCubeCache(), batchSize);
+		this.generatorStage = generatorStage;
 		this.provider = world.getCubeCache();
 		this.world = world;
 		this.vanillaGen = vanillaGen;
@@ -80,8 +83,8 @@ public class VanillaPopulationProcessor extends CubeProcessor {
 		Cube c01 = provider.getCube(c00.getX(), c00.getY(), c00.getZ() + 1);
 		Cube c11 = provider.getCube(c00.getX() + 1, c00.getY(), c00.getZ() + 1);
 		Cube c10 = provider.getCube(c00.getX() + 1, c00.getY(), c00.getZ());
-		return c01 != null && !c01.getGeneratorStage().isLessThan(GeneratorStage.POPULATION) &&
-				c11 != null && !c11.getGeneratorStage().isLessThan(GeneratorStage.POPULATION) &&
-				c10 != null && !c10.getGeneratorStage().isLessThan(GeneratorStage.POPULATION);
+		return c01 != null && !c01.getGeneratorStage().precedes(generatorStage) &&
+				c11 != null && !c11.getGeneratorStage().precedes(generatorStage) &&
+				c10 != null && !c10.getGeneratorStage().precedes(generatorStage);
 	}
 }

--- a/src/main/java/cubicchunks/worldgen/generator/vanilla/VanillaTerrainProcessor.java
+++ b/src/main/java/cubicchunks/worldgen/generator/vanilla/VanillaTerrainProcessor.java
@@ -58,12 +58,15 @@ import static cubicchunks.util.ChunkProviderOverworldAccess.setBiomesForGenerati
 import static cubicchunks.util.ChunkProviderOverworldAccess.setBlocksInChunk;
 
 public class VanillaTerrainProcessor extends CubeProcessor {
+	
+	private GeneratorStage surfaceStage;
 	private final ChunkProviderOverworld vanillaGen;
 	private ICubicWorldServer world;
 	private ServerCubeCache provider;
 
-	public VanillaTerrainProcessor(ICubicWorldServer world, ChunkProviderOverworld vanillaGen, int batchSize) {
+	public VanillaTerrainProcessor(GeneratorStage surfaceStage, ICubicWorldServer world, ChunkProviderOverworld vanillaGen, int batchSize) {
 		super("Terrain", world.getCubeCache(), batchSize);
+		this.surfaceStage = surfaceStage;
 		this.world = world;
 		this.provider = world.getCubeCache();
 		this.vanillaGen = vanillaGen;
@@ -142,7 +145,7 @@ public class VanillaTerrainProcessor extends CubeProcessor {
 		}
 		for (int cubeY = 0; cubeY < 16; cubeY++) {
 			Cube currCube = this.provider.getCube(cube.getX(), cubeY, cube.getZ());
-			currCube.setGeneratorStage(GeneratorStage.SURFACE);
+			currCube.setGeneratorStage(surfaceStage);
 			BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos();
 			for (int localX = 0; localX < 16; localX++) {
 				for (int localY = 0; localY < 16; localY++) {


### PR DESCRIPTION
- Changed GeneratorPipeline to not use predefined stages.
    - GeneratorStage.LIVE is used as the final stage in all pipelines.
    - All cubes on the client have GeneratorStage.LIVE
- Changed existing world types and processors according to the new pipeline and stage layout.