### PR TITLE
GeneratorPipeline optimization

### DIFF
--- a/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorldServer.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorldServer.java
@@ -110,10 +110,7 @@ public abstract class MixinWorldServer extends MixinWorld implements ICubicWorld
 
 		// wait for the cubes to be loaded
 		GeneratorPipeline pipeline = this.getGeneratorPipeline();
-		int numCubesTotal = pipeline.getNumCubes();
-		if (numCubesTotal > 0) {
-			pipeline.generateAll();
-		}
+		pipeline.processAll();
 
 		// don't save cubes here. Vanilla doesn't do that.
 		// and saving chunks here would be extremely slow

--- a/src/main/java/cubicchunks/worldgen/GeneratorPipeline.java
+++ b/src/main/java/cubicchunks/worldgen/GeneratorPipeline.java
@@ -25,10 +25,8 @@ package cubicchunks.worldgen;
 
 import cubicchunks.CubicChunks;
 import cubicchunks.server.ServerCubeCache;
-import cubicchunks.util.AddressTools;
-import cubicchunks.util.Progress;
+import cubicchunks.util.CubeCoords;
 import cubicchunks.util.processor.CubeProcessor;
-import cubicchunks.util.processor.QueueProcessor;
 import cubicchunks.world.cube.Cube;
 import cubicchunks.world.dependency.CubeDependency;
 import cubicchunks.worldgen.dependency.DependentCube;
@@ -36,20 +34,24 @@ import cubicchunks.worldgen.dependency.DependentCubeManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 
 public class GeneratorPipeline {
 
-	private static final int TickBudget = 40; // ms. There are only 50 ms per tick
+	private static final int MAX_CUBES_PER_TICK = 500;
 
-	private ServerCubeCache cubeProvider;
+	private final ServerCubeCache cubeProvider;
 
-	private List<GeneratorStage> stages;
+	private final List<GeneratorStage> stages;
 
-	private Map<String, GeneratorStage> stageMap;
+	private final Map<String, GeneratorStage> stageMap;
 
-	private DependentCubeManager dependentCubeManager;
+	private final DependentCubeManager dependentCubeManager;
+
+	private List<LinkedList<CubeCoords>> queues;
 
 
 	public GeneratorPipeline(ServerCubeCache cubeProvider) {
@@ -62,34 +64,29 @@ public class GeneratorPipeline {
 
 	public void addStage(GeneratorStage stage, CubeProcessor processor) {
 		stage.setOrdinal(this.stages.size());
-		stage.setProcessor(new StageProcessor(processor));
+		stage.setCubeProcessor(processor);
 		this.stages.add(stage);
 		this.stageMap.put(stage.getName(), stage);
 	}
 
 	public void checkStages() {
+
+		this.queues = new ArrayList<>(this.stages.size());
+
 		for (GeneratorStage stage : this.stages) {
 			if (!stage.isLastStage()) {
-				if (stage.getProcessor() == null) {
+				if (stage.getCubeProcessor() == null) {
 					throw new Error("Generator pipeline configured incorrectly! Stage " + stage.getName() +
 							" is null! Fix your WorldServerContext constructor!");
 				}
 			}
-		}
-	}
 
-
-	public int getNumCubes() {
-		int num = 0;
-
-		for (GeneratorStage stage : this.stages) {
-			if (!stage.isLastStage()) {
-				num += stage.getProcessor().processor.getNumInQueue();
-			}
+			this.queues.add(new LinkedList<>());
 		}
 
-		return num;
+
 	}
+
 
 	public DependentCubeManager getDependentCubeManager() {
 		return this.dependentCubeManager;
@@ -97,7 +94,7 @@ public class GeneratorPipeline {
 
 
 	public void resume(Cube cube) {
-		cube.getCurrentStage().getProcessor().processor.add(cube.getAddress());
+		this.queues.get(cube.getCurrentStage().getOrdinal()).add(cube.getCoords());
 	}
 
 	public void generate(Cube cube) {
@@ -129,129 +126,129 @@ public class GeneratorPipeline {
 		this.generate(cube);
 	}
 
+	int totalTime = 0;
+	int totalProcessed = 0;
+	int ticksSinceReport = 0;
+	int totalFinished = 0;
+
 	public int tick() {
 
 		long timeStart = System.currentTimeMillis();
 
-		// allocate time to each stage depending on busy it is
-		final int sizeCap = 500;
+		// Sum up the amount of work to be done.
 		int numCubes = 0;
-		for (GeneratorStage stage : this.stages) {
-			numCubes += Math.min(sizeCap, stage.getProcessor().processor.getNumInQueue());
+		for (Queue<CubeCoords> queue : this.queues) {
+			numCubes += Math.min(MAX_CUBES_PER_TICK, queue.size());
 		}
-		for (GeneratorStage stage : this.stages) {
-			if (numCubes <= 0) {
-				stage.getProcessor().share = 0;
-			} else {
-				int size = Math.min(sizeCap, stage.getProcessor().processor.getNumInQueue());
-				stage.getProcessor().share = (float) size/(float) numCubes;
-			}
+
+		// If there is nothing to do, return now.
+		if (numCubes < 0) {
+			return 0;
+		}
+
+		// Allocate load to each stage depending on busy it is.
+		int[] shares = new int[this.queues.size()];
+		for (int i = 0; i < this.stages.size(); ++i) {
+			int size = Math.min(MAX_CUBES_PER_TICK, this.queues.get(i).size());
+			shares[i] = Math.round(MAX_CUBES_PER_TICK * (float)size / (float)numCubes);
 		}
 
 		// process the queues
-		int numProcessed = 0;
-		for (GeneratorStage stage : this.stages) {
-
-			// process this stage according to its share
-			StageProcessor processor = stage.getProcessor();
-			if (processor.share <= 0) {
-				continue;
-			}
-
-			int numMsToProcess = (int) (Math.ceil(processor.share*TickBudget));
-			long stageTimeStart = System.currentTimeMillis();
-			int numStageProcessed = processor.processor.processQueueUntil(stageTimeStart + numMsToProcess);
-
-			numProcessed += numStageProcessed;
-
-			advanceCubes(processor.processor, stage);
+		int processed = 0;
+		for (int i = 0; i < this.queues.size(); ++i) {
+			GeneratorStage stage = this.stages.get(i);
+			processed += processStage(stage, shares[i]);
 		}
 
 		// reporting
 		long timeDiff = System.currentTimeMillis() - timeStart;
-		if (numProcessed > 0) {
-			CubicChunks.LOGGER.debug("Processed {} cubes in {} ms.", numProcessed, timeDiff);
-			for (GeneratorStage stage : this.stages) {
-				CubicChunks.LOGGER.debug(stage.getProcessor().processor.getProcessingReport());
-			}
-		}
+		totalTime += timeDiff;
+		totalProcessed += processed;
+		this.report();
 
-		return numProcessed;
+		return processed;
 	}
 
-	public void generateAll() {
-		for (GeneratorStage stage : this.stages) {
-			
-			QueueProcessor<Long> processor = stage.getProcessor().processor;
+	public void processAll() {
+		long timeStart = System.currentTimeMillis();
 
-			CubicChunks.LOGGER.info("Stage: {}", processor.getName());
+		// Process all queues until they are completely empty.
+		boolean done = false;
+		while (!done) {
+			done = true;
 
-			// process all the cubes in this stage at once
-			int numProcessed = 0;
-			int round = 0;
-			do {
-				CubicChunks.LOGGER.info("\tround {} - {} cubes", ++round, processor.getNumInQueue());
-				Progress progress = new Progress(processor.getNumInQueue(), 1000);
-				numProcessed = processor.processQueue(progress);
-				advanceCubes(processor, stage);
-				CubicChunks.LOGGER.info("\t\tprocessed {}", numProcessed);
-			} while (numProcessed > 0 && processor.getNumInQueue() > 0);
-		}
-	}
-
-	private void advanceCubes(QueueProcessor<Long> processor, GeneratorStage stage) {
-
-		// The last stage for all GeneratorPipelines is GeneratorStage.LIVE. If LIVE is the next stage,
-		// all cubes have reached their target stage. Therefore unnecessary checks can be avoided.
-		
-		// move the processed entries into the next stage of the pipeline
-		if (stage.getOrdinal() + 1 < this.stages.size()) {
-			
-			GeneratorStage nextStage = this.stages.get(stage.getOrdinal() + 1);	
-			
-			for (long address : processor.getProcessedAddresses()) {
-				int cubeX = AddressTools.getX(address);
-				int cubeY = AddressTools.getY(address);
-				int cubeZ = AddressTools.getZ(address);
-
-				Cube cube = this.cubeProvider.getCube(cubeX, cubeY, cubeZ);
-				
-				// Clear the cube's dependency.
-				this.dependentCubeManager.unregister(cube);
-				
-				// Advance the cube's stage.
-				cube.setCurrentStage(nextStage);
-
-				// Update cubes depending on this cube.
-				this.dependentCubeManager.updateDependents(cube);
-
-				// If the next stage is not the cube's target stage, carry on.
-				if (nextStage.precedes(cube.getTargetStage())) {
-					generate(cube);
+			for (int i = 0; i < this.stages.size(); ++i) {
+				GeneratorStage stage = this.stages.get(i);
+				int processed = processStage(stage);
+				totalProcessed += processed;
+				if (processed > 0) {
+					done = false;
+					break;
 				}
 			}
-		} 
-				
-		else {
-			for (long address : processor.getProcessedAddresses()) {
-				int cubeX = AddressTools.getX(address);
-				int cubeY = AddressTools.getY(address);
-				int cubeZ = AddressTools.getZ(address);
-
-				Cube cube = this.cubeProvider.getCube(cubeX, cubeY, cubeZ);
-
-				// Clear the cube's dependency.
-				this.dependentCubeManager.unregister(cube);
-
-				// Update the cube's stage.
-				cube.setCurrentStage(GeneratorStage.LIVE);
-
-				// Update cubes depending on this cube.
-				this.dependentCubeManager.updateDependents(cube);
-			}
 		}
+
+		long timeDiff = System.currentTimeMillis() - timeStart;
+		totalTime += timeDiff;
+
+		this.report();
 	}
 
+	public int processStage(GeneratorStage stage, int maxCubes) {
+
+		GeneratorStage nextStage = stage.getOrdinal() < this.stages.size() - 1 ? this.stages.get(stage.getOrdinal() + 1) : GeneratorStage.LIVE;
+		Queue<CubeCoords> queue = this.queues.get(stage.getOrdinal());
+		CubeProcessor processor = stage.getCubeProcessor();
+
+		int processed = 0;
+		while (!queue.isEmpty() && processed < maxCubes) {
+			Cube cube = this.cubeProvider.getCube(queue.poll());
+
+			// If the cube has been unloaded, skip it.
+			if (cube == null) {
+				continue;
+			}
+
+			// If the cube has passed this stage, skip it.
+			if (cube.getCurrentStage() != stage) {
+				continue;
+			}
+
+			processor.calculate(cube);
+
+			// Free the cube's requirements.
+			this.dependentCubeManager.unregister(cube);
+
+			// Advance the cube's stage.
+			cube.setCurrentStage(nextStage);
+
+			// Update cubes depending on this cube.
+			this.dependentCubeManager.updateDependents(cube);
+
+			// If the next stage is not the cube's target stage, carry on.
+			if (nextStage != GeneratorStage.LIVE && !cube.hasReachedTargetStage()) {
+				generate(cube);
+			} else {
+				++totalFinished;
+			}
+
+			++processed;
+		}
+
+		return processed;
+	}
+
+	public int processStage(GeneratorStage stage) {
+		return processStage(stage, Integer.MAX_VALUE);
+	}
+
+	private void report() {
+		++ticksSinceReport;
+		if (ticksSinceReport == 20) {
+			CubicChunks.LOGGER.info("Processed: {}/s Finished: {}/s", ((double) totalProcessed * 1000f) / totalTime, ((double) totalFinished * 1000f) / totalTime);
+			ticksSinceReport = 0;
+		}
+	}
 
 	public GeneratorStage getStage(String name) {
 		return this.stageMap.get(name);

--- a/src/main/java/cubicchunks/worldgen/GeneratorStage.java
+++ b/src/main/java/cubicchunks/worldgen/GeneratorStage.java
@@ -24,6 +24,7 @@
 
 package cubicchunks.worldgen;
 
+import cubicchunks.util.processor.CubeProcessor;
 import cubicchunks.world.dependency.CubeDependencyProvider;
 import net.minecraft.world.World;
 
@@ -41,7 +42,7 @@ public abstract class GeneratorStage implements CubeDependencyProvider {
 	
 	private int ordinal;
 	
-	private StageProcessor processor;
+	private CubeProcessor processor;
 	
 		
 	public GeneratorStage(String name) {
@@ -70,11 +71,11 @@ public abstract class GeneratorStage implements CubeDependencyProvider {
 	}
 	
 	
-	public void setProcessor(StageProcessor processor) {
+	public void setCubeProcessor(CubeProcessor processor) {
 		this.processor = processor;
 	}
 
-	public StageProcessor getProcessor() {
+	public CubeProcessor getCubeProcessor() {
 		return this.processor;
 	}
 	

--- a/src/main/java/cubicchunks/worldgen/StageProcessor.java
+++ b/src/main/java/cubicchunks/worldgen/StageProcessor.java
@@ -24,14 +24,14 @@
 
 package cubicchunks.worldgen;
 
-import cubicchunks.util.processor.QueueProcessor;
+import cubicchunks.util.processor.CubeProcessor;
 
 public class StageProcessor {
 
-	public QueueProcessor<Long> processor;
+	public CubeProcessor processor;
 	public float share;
 
-	public StageProcessor(QueueProcessor<Long> processor) {
+	public StageProcessor(CubeProcessor processor) {
 		this.processor = processor;
 		this.share = 0f;
 	}


### PR DESCRIPTION
Because the generator pipeline eats up lots of CPU cycles, I decided to clean it up and get rid of some stuff. QueueProcessor contains lots of expensive operations (regarding its 4 set structure), which are no longer required. Cubes will no longer be skipped during processing, because all required cubes are guaranteed to be available, therefor keeping track of skipped cubes and requeing them is no longer necessary. By using a linked list, adding new work to the processing queues and removing individual entries is improved.

Additionally, I decided to move the queues into GeneratorPipeline and calling CubeProcessor.calculate directly. Thus, the number of convoluted accesses to other objects is reduced.