### PR TITLE
- Added proof of concept parallelization.

### DIFF
--- a/src/main/java/cubicchunks/world/cube/Cube.java
+++ b/src/main/java/cubicchunks/world/cube/Cube.java
@@ -354,6 +354,10 @@ public class Cube {
 		return this.currentStage;
 	}
 
+	public GeneratorStage getNextStage() {
+		return this.currentStage.getNextStage();
+	}
+
 	public boolean isBeforeStage(GeneratorStage stage) {
 		return this.getCurrentStage().precedes(stage);
 	}
@@ -595,6 +599,7 @@ public class Cube {
 	public LightUpdateData getLightUpdateData() {
 		return this.lightUpdateData;
 	}
+
 
 	public static class LightUpdateData {
 		private final Cube cube;

--- a/src/main/java/cubicchunks/worldgen/GeneratorStage.java
+++ b/src/main/java/cubicchunks/worldgen/GeneratorStage.java
@@ -41,6 +41,8 @@ public abstract class GeneratorStage implements CubeDependencyProvider {
 	private boolean isLast;
 	
 	private int ordinal;
+
+	private GeneratorStage nextStage;
 	
 	private CubeProcessor processor;
 	
@@ -50,6 +52,14 @@ public abstract class GeneratorStage implements CubeDependencyProvider {
 		this.isLast = false;
 	}
 	
+
+	public void setNextStage(GeneratorStage nextStage) {
+		this.nextStage = nextStage;
+	}
+
+	public GeneratorStage getNextStage() {
+		return this.nextStage;
+	}
 
 	@Override
 	public String toString() {
@@ -84,7 +94,7 @@ public abstract class GeneratorStage implements CubeDependencyProvider {
 		this.ordinal = ordinal;
 	}
 	
-	int getOrdinal() {
+	public int getOrdinal() {
 		return this.ordinal;
 	}
 

--- a/src/main/java/cubicchunks/worldgen/concurrency/CubeWorker.java
+++ b/src/main/java/cubicchunks/worldgen/concurrency/CubeWorker.java
@@ -1,0 +1,163 @@
+package cubicchunks.worldgen.concurrency;
+
+import cubicchunks.CubicChunks;
+import cubicchunks.util.CubeCoords;
+import cubicchunks.world.cube.Cube;
+
+// TODO: Add means to properly shutdown.
+
+public abstract class CubeWorker implements Runnable {
+
+	private final String name;
+
+	private final CubeWorkerQueue queue;
+
+	private CubeCoords assignment;
+
+	// Synchronization
+
+	private final Object pauseMutex;
+
+	private boolean shouldRun;
+
+	private boolean running;
+
+	// Reporting
+
+	private long totalProcessed;
+
+	private long processedSinceReset;
+
+	private long totalDuration;
+
+	private long durationSinceReset;
+
+	// Workload management
+
+	// TODO: Make dynamic
+	private final int batchSize = 500;
+
+
+
+	public CubeWorker(String name, CubeWorkerQueue queue) {
+		this.name = name;
+		this.queue = queue;
+		this.pauseMutex = new Object();
+		this.shouldRun = false;
+		this.running = false;
+	}
+
+
+	public void assign(CubeCoords coords) {
+		synchronized (this) {
+			this.assignment = coords;
+		}
+	}
+
+	public CubeCoords getAssignment() {
+		return this.assignment;
+	}
+
+
+	public abstract boolean process(Cube cube);
+
+	public void run() {
+
+		this.pause();
+
+		while (true) {
+			this.waitUntilUnpaused();
+
+			long timeStart = System.currentTimeMillis();
+
+			int processed = 0;
+			while (this.canRun()) {
+				// Get the next cube and process it.
+				Cube cube = this.queue.poll(this);
+
+				// If there is available cube, stop processing and continue in the next tick.
+				if (cube == null) {
+					break;
+				}
+
+				// Otherwise process it.
+				if (this.process(cube)) {
+					++processed;
+				}
+			}
+
+			long timeDiff = System.currentTimeMillis() - timeStart;
+
+			// Reporting
+			this.totalDuration += timeDiff;
+			this.durationSinceReset += timeDiff;
+			this.totalProcessed += processed;
+			this.processedSinceReset += processed;
+
+			this.pause();
+		}
+	}
+
+
+	// Synchronization
+
+	public void signalPause() {
+		synchronized (this.pauseMutex) {
+			this.shouldRun = false;
+		}
+	}
+
+	public void signalUnpause() {
+		synchronized (this.pauseMutex) {
+			this.shouldRun = true;
+			this.pauseMutex.notifyAll();
+		}
+	}
+
+	public boolean canRun() {
+		synchronized (this.pauseMutex) {
+			return !this.shouldRun;
+		}
+	}
+
+	private void pause() {
+		synchronized (this.pauseMutex) {
+			this.running = false;
+			this.pauseMutex.notifyAll();
+		}
+
+	}
+
+	private void waitUntilUnpaused() {
+		synchronized (this.pauseMutex) {
+			while (!this.shouldRun) {
+				try {
+					this.pauseMutex.wait();
+				} catch (InterruptedException e) {
+					// TODO
+				}
+			}
+			this.running = true;
+		}
+	}
+
+	public void waitUntilPaused() {
+		synchronized (this.pauseMutex) {
+			while (this.running) {
+				try {
+					this.pauseMutex.wait();
+				} catch (InterruptedException e) {
+					// TODO
+				}
+			}
+		}
+	}
+
+	// Reporting
+
+	public void report() {
+		CubicChunks.LOGGER.info("{}", this.name);
+		CubicChunks.LOGGER.info("total: {} cubes at {} cubes/s", totalProcessed, ((double) totalProcessed) / totalDuration);
+	}
+
+}

--- a/src/main/java/cubicchunks/worldgen/concurrency/CubeWorkerQueue.java
+++ b/src/main/java/cubicchunks/worldgen/concurrency/CubeWorkerQueue.java
@@ -1,0 +1,97 @@
+package cubicchunks.worldgen.concurrency;
+
+import cubicchunks.CubicChunks;
+import cubicchunks.util.CubeCoords;
+import cubicchunks.world.ICubeCache;
+import cubicchunks.world.cube.Cube;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class CubeWorkerQueue {
+
+	// TODO: Dynamicalize
+	private static final int workerDistance = 5;
+
+
+	private final String name;
+
+	private final ICubeCache cubeCache;
+
+	private final Queue<CubeCoords> queue;
+
+	private final List<CubeWorker> workers;
+
+
+	public CubeWorkerQueue(String name, ICubeCache cubeCache) {
+		this.name = name;
+		this.cubeCache = cubeCache;
+		this.queue = new ConcurrentLinkedQueue<>();
+		this.workers = new ArrayList<>();
+	}
+
+
+	public void register(CubeWorker worker) {
+		this.workers.add(worker);
+	}
+
+	public void add(CubeCoords coords) {
+		synchronized (this) {
+			this.queue.add(coords);
+		}
+	}
+
+	public Cube poll(CubeWorker pollingWorker) {
+		synchronized (this.cubeCache) {
+			synchronized (pollingWorker) {
+				// Clear the polling worker's current assignment.
+				pollingWorker.assign(null);
+
+				// Iterate through the queue until an available cube is found.
+				Iterator<CubeCoords> iter = this.queue.iterator();
+				CubeCoords coords = iter.hasNext() ? iter.next() : null;
+
+				while (coords != null) {
+					if (isAvailable(coords)) {
+						iter.remove();
+
+						// Get the cube.
+						Cube cube = this.cubeCache.getCube(coords);
+
+						// If the cube exists, assign it to the worker and return it.
+						if (cube != null) {
+							pollingWorker.assign(coords);
+							return cube;
+						}
+						// Otherwise continue.
+					}
+
+					coords = iter.hasNext() ? iter.next() : null;
+				}
+
+				// If no available cube was found, return null.
+			}
+		}
+
+		return null;
+	}
+
+	public boolean isAvailable(CubeCoords coords) {
+		for (CubeWorker worker : this.workers) {
+			CubeCoords assignment = worker.getAssignment();
+			if (assignment != null && (
+					Math.abs(assignment.getCubeX() - coords.getCubeX()) < workerDistance ||
+							Math.abs(assignment.getCubeZ() - coords.getCubeZ()) < workerDistance)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public void report() {
+		CubicChunks.LOGGER.info("{}: {} remaining.", this.name,  this.queue.size());
+	}
+}

--- a/src/main/java/cubicchunks/worldgen/concurrency/GeneratorWorker.java
+++ b/src/main/java/cubicchunks/worldgen/concurrency/GeneratorWorker.java
@@ -1,0 +1,59 @@
+package cubicchunks.worldgen.concurrency;
+
+import cubicchunks.CubicChunks;
+import cubicchunks.util.processor.CubeProcessor;
+import cubicchunks.world.cube.Cube;
+import cubicchunks.worldgen.GeneratorPipeline;
+import cubicchunks.worldgen.GeneratorStage;
+import cubicchunks.worldgen.dependency.DependentCubeManager;
+
+public class GeneratorWorker extends CubeWorker {
+
+	private final GeneratorPipeline generatorPipeline;
+
+	private final DependentCubeManager dependentCubeManager;
+
+	// TODO: Make private
+	public final GeneratorStage generatorStage;
+
+	private final CubeProcessor processor;
+
+
+	public GeneratorWorker(GeneratorPipeline generatorPipeline, GeneratorStage generatorStage, CubeWorkerQueue queue) {
+		super(generatorStage.getName(), queue);
+		this.generatorPipeline = generatorPipeline;
+		this.dependentCubeManager = generatorPipeline.getDependentCubeManager();
+		this.generatorStage = generatorStage;
+		this.processor = generatorStage.getCubeProcessor();
+	}
+
+
+	@Override
+	public boolean process(Cube cube) {
+
+		// If the cube is not in the correct stage, don't do anything to it.
+		if (cube.getCurrentStage() != this.generatorStage) {
+			return false;
+		}
+
+		// Process the cube.
+		this.processor.calculate(cube);
+
+		// Free the cube's requirements.
+		this.dependentCubeManager.unregister(cube);
+
+		// Advance the cube's stage.
+		cube.setCurrentStage(this.generatorStage.getNextStage());
+
+		// Update the cube's dependents.
+		this.dependentCubeManager.updateDependents(cube);
+
+		// If the cube has not yet reached its target stage, advance it to the next stage.
+		if (cube.getCurrentStage() != GeneratorStage.LIVE && !cube.hasReachedTargetStage()) {
+			this.generatorPipeline.generate(cube);
+		}
+
+		return true;
+	}
+
+}


### PR DESCRIPTION
At the current point in time, this is a proof of concept and not ready to merge. Lots of changes need to be made.

The general idea of this change is #29. Each stage has its own thread safe queue of CubeCoords, scheduled for processing. During GeneratorPipeline.tick, GeneratorWorkers are unpaused and process these queues in parallel. The queues are responsible for assigning work to the GeneratorWorkers.

In general, two workers must not process to cubes A and B at the same time, if processing of either of these cubes affects processing of the other cube. Therefor, two threads can never simultaneously process cubes in the same column. Since some operations affect nearby cubes/columns, it is necessary to maintain a safety distance between workers.

For example: Assuming the lighting stage affects not only the current column, but all 7 adjacent columns as well,  the safety distance must be set to at least 2, to prevent interference.

All queues are aware of all workers and will ensure that no two workers operate on interfering cubes.