### PR TITLE
Fixed night vision potions causing a blackout below y:0

### DIFF
--- a/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorld.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorld.java
@@ -32,6 +32,8 @@ import cubicchunks.world.ICubeCache;
 import cubicchunks.world.ICubicWorld;
 import cubicchunks.world.NotCubicChunksWorldException;
 import cubicchunks.world.cube.Cube;
+import cubicchunks.world.provider.ICubicWorldProvider;
+import cubicchunks.world.provider.VanillaCubicProvider;
 import cubicchunks.world.type.ICubicWorldType;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -95,6 +97,10 @@ public abstract class MixinWorld implements ICubicWorld, IConfigUpdateListener {
 		this.minHeight = CubicChunks.Config.DEFAULT_MIN_WORLD_HEIGHT;
 		//don't want to make world implement IConfigChangeListener
 		CubicChunks.addConfigChangeListener(this);
+
+		if(!(this.provider instanceof ICubicWorldProvider)) { // if the provider is vanilla, wrap it
+			this.provider = new VanillaCubicProvider(this, provider, null);
+		}
 	}
 	//from ConfigChangeListener
 	@Override public void onConfigUpdate(CubicChunks.Config config) {

--- a/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorldServer.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorldServer.java
@@ -30,20 +30,17 @@ import cubicchunks.server.ChunkGc;
 import cubicchunks.server.PlayerCubeMap;
 import cubicchunks.server.ServerCubeCache;
 import cubicchunks.util.Coords;
-import cubicchunks.util.CubeCoords;
 import cubicchunks.world.CubeWorldEntitySpawner;
 import cubicchunks.world.CubicChunksSaveHandler;
 import cubicchunks.world.ICubicWorldServer;
 import cubicchunks.world.IProviderExtras;
 import cubicchunks.world.provider.ICubicWorldProvider;
-import cubicchunks.world.provider.VanillaCubicProvider;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.server.management.PlayerChunkMap;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldEntitySpawner;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.biome.Biome;
-import net.minecraft.world.gen.ChunkProviderServer;
 
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Implements;
@@ -76,11 +73,6 @@ public abstract class MixinWorldServer extends MixinWorld implements ICubicWorld
 		this.isCubicWorld = true;
 
 		this.entitySpawner = new CubeWorldEntitySpawner();
-
-		if(!(this.provider instanceof ICubicWorldProvider)) { // if the provider is vanilla, wrap it
-			this.provider = new VanillaCubicProvider(this, provider,
-					((ChunkProviderServer)this.chunkProvider).chunkGenerator); // give it the old generator so it does not need to allocate a new one
-		}
 
 		this.chunkProvider = new ServerCubeCache(this, 
 				((ICubicWorldProvider)this.provider).createCubeGenerator());

--- a/src/main/java/cubicchunks/server/PlayerCubeMapEntry.java
+++ b/src/main/java/cubicchunks/server/PlayerCubeMapEntry.java
@@ -29,7 +29,6 @@ import cubicchunks.network.PacketCubeBlockChange;
 import cubicchunks.network.PacketDispatcher;
 import cubicchunks.network.PacketUnloadCube;
 import cubicchunks.util.AddressTools;
-import cubicchunks.util.CubeCoords;
 import cubicchunks.world.ICubicWorld;
 import cubicchunks.world.IProviderExtras;
 import cubicchunks.world.cube.Cube;

--- a/src/main/java/cubicchunks/world/provider/VanillaCubicProvider.java
+++ b/src/main/java/cubicchunks/world/provider/VanillaCubicProvider.java
@@ -61,41 +61,42 @@ public class VanillaCubicProvider extends CubicWorldProvider {
 
 		boolean useProvider = false;
 
-		if(!worldObj.isRemote)
-		if(worldObj.getWorldType() instanceof ICubicWorldType) { // Who do we trust!??!?! D:
+		if(!worldObj.isRemote) {
+			if (worldObj.getWorldType() instanceof ICubicWorldType) { // Who do we trust!??!?! D:
 
-			// nasty hack heuristic to see if provider asks its WorldType for a chunk generator
-			//ReflectionUtil.setFieldValueSrg(wp, "field_76577_b", HEURISTIC_WORLDTYPE);
-			provider.terrainType = HEURISTIC_WORLDTYPE;
+				// nasty hack heuristic to see if provider asks its WorldType for a chunk generator
+				//ReflectionUtil.setFieldValueSrg(wp, "field_76577_b", HEURISTIC_WORLDTYPE);
+				provider.terrainType = HEURISTIC_WORLDTYPE;
 
-			IChunkGenerator pro_or_null = provider.createChunkGenerator();
+				IChunkGenerator pro_or_null = provider.createChunkGenerator();
 
-			// clean up
-			//ReflectionUtil.setFieldValueSrg(provider, "field_76577_b", worldObj.getWorldType());
-			provider.terrainType = worldObj.getWorldType();
+				// clean up
+				//ReflectionUtil.setFieldValueSrg(provider, "field_76577_b", worldObj.getWorldType());
+				provider.terrainType = worldObj.getWorldType();
 
-			if(pro_or_null != null) { // It will be null if it tries to get one form WorldType
+				if (pro_or_null != null) { // It will be null if it tries to get one form WorldType
 
-				// It was from a vanilla WorldProvider... use it
-				cubeGen = new VanillaCompatibilityGenerator(
+					// It was from a vanilla WorldProvider... use it
+					cubeGen = new VanillaCompatibilityGenerator(
 							reUse == null ? pro_or_null : reUse,
 							world);
-			}else{
+				} else {
 
-				// It was from WorldType, try to use cubic generator
-				cubeGen   = ((ICubicWorldType)worldObj.getWorldType()).createCubeGenerator(getCubicWorld());
-				if(cubeGen == null) {
-					useProvider = true;
+					// It was from WorldType, try to use cubic generator
+					cubeGen = ((ICubicWorldType) worldObj.getWorldType()).createCubeGenerator(getCubicWorld());
+					if (cubeGen == null) {
+						useProvider = true;
+					}
 				}
+			} else {
+				useProvider = true;
 			}
-		}else{
-			useProvider = true;
-		}
 
-		if(useProvider) {
-			cubeGen = new VanillaCompatibilityGenerator(
-							reUse == null ? provider.createChunkGenerator() : reUse,
-							world);
+			if (useProvider) {
+				cubeGen = new VanillaCompatibilityGenerator(
+						reUse == null ? provider.createChunkGenerator() : reUse,
+						world);
+			}
 		}
 	}
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -41,7 +41,7 @@ TODO: figure out how to automatically remove log4j2.xml for release
         </Routing>
     </Appenders>
     <Loggers>
-        <!--<Logger level="info" name="com.mojang" additivity="false">
+        <Logger level="info" name="com.mojang" additivity="false">
             <AppenderRef ref="SysOut" level="ALL" />
             <AppenderRef ref="File" />
             <AppenderRef ref="ServerGuiConsole" level="INFO" />
@@ -53,7 +53,7 @@ TODO: figure out how to automatically remove log4j2.xml for release
             <AppenderRef ref="SysOut" level="ALL" />
             <AppenderRef ref="File" />
             <AppenderRef ref="ServerGuiConsole" level="ALL" />
-        </Logger>-->
+        </Logger>
         <Root level="all">
             <AppenderRef ref="FmlSysOut" />
             <AppenderRef ref="ServerGuiConsole" level="INFO" />


### PR DESCRIPTION
Only MixinWorldServer's vanilla provider was being wrapped. This caused a problem where void fog would give you a blackout when using a night vision potion!
So the wrapping code was moved to MixinWorld.