### PR TITLE
Do not merge it. Attempt to use Cubes instead of Chunks in EntityTracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ classes/
 ########
 *.bak
 *.hprof
+*~
 
 # Libraries #
 #############

--- a/src/main/java/cubicchunks/asm/mixin/core/common/MixInEntityTracker.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/common/MixInEntityTracker.java
@@ -1,0 +1,79 @@
+package cubicchunks.asm.mixin.core.common;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import cubicchunks.world.cube.Cube;
+import cubichunks.entity.ICubicEntityTracker;
+import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityTracker;
+import net.minecraft.entity.EntityTrackerEntry;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.play.server.SPacketEntityAttach;
+import net.minecraft.network.play.server.SPacketSetPassengers;
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+@Mixin(EntityTracker.class)
+public abstract class MixInEntityTracker implements ICubicEntityTracker {
+
+	@Shadow @Final @Mutable public Set<EntityTrackerEntry> entries = Sets.<EntityTrackerEntry>newHashSet();
+
+	public void sendLeashedEntitiesInCube(EntityPlayerMP player, Cube cubeIn)
+	{
+        List<Entity> list = Lists.<Entity>newArrayList();
+        List<Entity> list1 = Lists.<Entity>newArrayList();
+
+        for (EntityTrackerEntry entitytrackerentry : this.entries)
+        {
+            Entity entity = entitytrackerentry.getTrackedEntity();
+
+            if (entity != player && 
+            		entity.chunkCoordX == cubeIn.getX() && 
+            		entity.chunkCoordZ == cubeIn.getZ() &&
+            		entity.chunkCoordY == cubeIn.getY())
+            {
+                entitytrackerentry.updatePlayerEntity(player);
+
+                if (entity instanceof EntityLiving && ((EntityLiving)entity).getLeashedToEntity() != null)
+                {
+                    list.add(entity);
+                }
+
+                if (!entity.getPassengers().isEmpty())
+                {
+                    list1.add(entity);
+                }
+            }
+        }
+
+        if (!list.isEmpty())
+        {
+            for (Entity entity1 : list)
+            {
+                player.connection.sendPacket(new SPacketEntityAttach(entity1, ((EntityLiving)entity1).getLeashedToEntity()));
+            }
+        }
+
+        if (!list1.isEmpty())
+        {
+            for (Entity entity2 : list1)
+            {
+                player.connection.sendPacket(new SPacketSetPassengers(entity2));
+            }
+        }
+	}
+
+}

--- a/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorldServer.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorldServer.java
@@ -23,6 +23,7 @@
  */
 package cubicchunks.asm.mixin.core.common;
 
+import net.minecraft.entity.EntityTracker;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.server.management.PlayerChunkMap;
 import net.minecraft.util.math.BlockPos;
@@ -50,6 +51,7 @@ import cubicchunks.world.CubicSaveHandler;
 import cubicchunks.world.ICubicWorldServer;
 import cubicchunks.world.NotCubicChunksWorldException;
 import cubicchunks.world.provider.ICubicWorldProvider;
+import cubichunks.entity.ICubicEntityTracker;
 import mcp.MethodsReturnNonnullByDefault;
 
 /**
@@ -92,6 +94,10 @@ public abstract class MixinWorldServer extends MixinWorld implements ICubicWorld
 		this.chunkGc.tick();
 	}
 
+	@Override public ICubicEntityTracker getCubicEntityTracker() {
+		return (ICubicEntityTracker)this.world$getEntityTracker();
+	}
+	
 	@Override public CubeProviderServer getCubeCache() {
 		if (!this.isCubicWorld()) {
 			throw new NotCubicChunksWorldException();
@@ -136,6 +142,14 @@ public abstract class MixinWorldServer extends MixinWorld implements ICubicWorld
 	@Intrinsic
 	public boolean world$canCreatureTypeSpawnHere(EnumCreatureType type, Biome.SpawnListEntry entry, BlockPos pos) {
 		return this.canCreatureTypeSpawnHere(type, entry, pos);
+	}
+	//==============================================
+	@Shadow
+	public abstract EntityTracker getEntityTracker();
+
+	@Intrinsic
+	public EntityTracker world$getEntityTracker() {
+		return this.getEntityTracker();
 	}
 	//==============================================
 }

--- a/src/main/java/cubicchunks/server/ColumnWatcher.java
+++ b/src/main/java/cubicchunks/server/ColumnWatcher.java
@@ -154,9 +154,9 @@ class ColumnWatcher extends PlayerChunkMapEntry implements XZAddressable {
 			PacketColumn message = new PacketColumn(this.getColumn());
 			for (EntityPlayerMP player : this.getPlayers()) {
 				PacketDispatcher.sendTo(message, player);
-				playerCubeMap.getWorldServer()
+/*				playerCubeMap.getWorldServer()
 					.getEntityTracker()
-					.sendLeashedEntitiesInChunk(player, this.getColumn());
+					.sendLeashedEntitiesInChunk(player, this.getColumn());*/
 			}
 			setSentToPlayers.invoke(this, true);
 		} catch (Throwable throwable) {

--- a/src/main/java/cubicchunks/server/CubeWatcher.java
+++ b/src/main/java/cubicchunks/server/CubeWatcher.java
@@ -191,6 +191,9 @@ public class CubeWatcher implements XYZAddressable, ITicket {
 		for (WatcherPlayerEntry playerEntry : this.players.valueCollection()) {
 			//don't send entities here, Column sends them.
 			//TODO: send entities per cube? Sending all entities from column may be bad on multiplayer
+			playerCubeMap.getWorld()
+				.getCubicEntityTracker()
+				.sendLeashedEntitiesInCube(playerEntry.player, cube);
 			sendToPlayer(playerEntry.player);
 		}
 

--- a/src/main/java/cubicchunks/world/ICubicWorldServer.java
+++ b/src/main/java/cubicchunks/world/ICubicWorldServer.java
@@ -33,6 +33,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import cubicchunks.lighting.FirstLightProcessor;
 import cubicchunks.server.CubeProviderServer;
 import cubicchunks.server.PlayerCubeMap;
+import cubichunks.entity.ICubicEntityTracker;
 import mcp.MethodsReturnNonnullByDefault;
 
 @ParametersAreNonnullByDefault
@@ -52,4 +53,6 @@ public interface ICubicWorldServer extends ICubicWorld {
 	@Nullable Biome.SpawnListEntry getSpawnListEntryForTypeAt(EnumCreatureType type, BlockPos pos);
 
 	boolean canCreatureTypeSpawnHere(EnumCreatureType type, Biome.SpawnListEntry entry, BlockPos pos);
+
+	ICubicEntityTracker getCubicEntityTracker();
 }

--- a/src/main/java/cubicchunks/worldgen/generator/custom/CustomPopulationProcessor.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/CustomPopulationProcessor.java
@@ -49,11 +49,11 @@ public class CustomPopulationProcessor {
 		this.biomeFeaturesMap = new HashMap<>();
 
 		// for now use global for all biomes
-		for (Biome biome : Biome.REGISTRY) {
+		for (Object biome : Biome.REGISTRY) {
 			if (biome == null) {
 				continue;
 			}
-			this.biomeFeaturesMap.put(biome, new BiomeFeatures(world, biome));
+			this.biomeFeaturesMap.put((Biome) biome, new BiomeFeatures(world, (Biome) biome));
 		}
 	}
 

--- a/src/main/java/cubichunks/entity/ICubicEntityTracker.java
+++ b/src/main/java/cubichunks/entity/ICubicEntityTracker.java
@@ -1,0 +1,9 @@
+package cubichunks.entity;
+
+import cubicchunks.world.cube.Cube;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+public interface ICubicEntityTracker {
+
+	public void sendLeashedEntitiesInCube(EntityPlayerMP player, Cube cubeIn);
+}


### PR DESCRIPTION
I hardly understand what I'm doing. This is a whole new level of Java programming for me.
What I tried to do is to create "MixInEntityTracker" a same way as you create "MixinWorldServer" and add an interface so a new cubic methods could be called from "ICubicWorldServer" in "CubeWatcher".
But when I tried to compile this new version I receive exception in a moment of test:
```
cubicchunks.TestWorldServerMixin > testInitCubicWorldIsCubic FAILED
    java.lang.ClassCastException at TestWorldServerMixin.java:83

cubicchunks.TestWorldServerMixin > testWorldMaxHeightVanillaCompatibility FAILED
    java.lang.ClassCastException at TestWorldServerMixin.java:83

cubicchunks.TestWorldServerMixin > testCubicWorldMaxHeight FAILED
    java.lang.ClassCastException at TestWorldServerMixin.java:83

cubicchunks.TestWorldServerMixin > testCubicWorldMinHeight FAILED
    java.lang.ClassCastException at TestWorldServerMixin.java:83

cubicchunks.TestWorldServerMixin > testWorldMinHeightVanillaCompatibility FAILED
    java.lang.ClassCastException at TestWorldServerMixin.java:83
```
There is two options: either you will spent more time on explanations than save from my help or an opposite. Probably you could point me to some manuals?

EDIT: Ok, I forgot to change cubicchunks.mixins.core.json Have no idea what it do. Also where is "cubicchunks.mixins.refmap". Is it generated? Or I should change it manually...