### PR TITLE
Falling block height limits fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -189,7 +189,7 @@ dependencies {
     testCompile("org.mockito:mockito-core:2.1.0-RC.2")
     testCompile("org.spongepowered:launchwrappertestsuite:1.0-SNAPSHOT")
 
-    compile("org.spongepowered:mixin:0.5.11-SNAPSHOT") {
+    compile("org.spongepowered:mixin:0.6.4-SNAPSHOT") {
         exclude(mapOf("module" to "launchwrapper"))
         exclude(mapOf("module" to "guava"))
         exclude(mapOf("module" to "gson"))
@@ -234,7 +234,7 @@ shadowJar {
     relocate("com.flowpowered", "cubicchunks.com.flowpowered")
     /*
      Mixin shouldn"t be relocated. Mixin dependencies:
-     org.spongepowered:mixin:0.5.5-SNAPSHOT
+     org.spongepowered:mixin:0.6.4-SNAPSHOT
      +--- org.slf4j:slf4j-api:1.7.7
      +--- commons-codec:commons-codec:1.9
      +--- org.ow2.asm:asm-commons:5.0.3

--- a/src/main/java/cubicchunks/asm/JvmNames.java
+++ b/src/main/java/cubicchunks/asm/JvmNames.java
@@ -32,6 +32,7 @@ public class JvmNames {
     // We sort variables alphabetically here to make finding pre-existing constants easier
     // If you add a new one, please follow this sorting instead of adding them at the end
     public static final String
+        BLOCK_FALLING = "Lnet/minecraft/block/BlockFalling;",
         BLOCK_POS = "Lnet/minecraft/util/math/BlockPos;",
         CHUNK = "Lnet/minecraft/world/chunk/Chunk;",
         CHUNK_CACHE = "Lnet/minecraft/world/ChunkCache;",
@@ -40,6 +41,7 @@ public class JvmNames {
         COMMAND_TELEPORT = "Lnet/minecraft/command/server/CommandTeleport;",
         COMMAND_TP = "Lnet/minecraft/command/CommandTP;",
         ENTITY = "Lnet/minecraft/entity/Entity;",
+        ENTITY_FALLING_BLOCK = "Lnet/minecraft/entity/item/EntityFallingBlock;",
         ENTITY_PLAYER_MP = "Lnet/minecraft/entity/player/EntityPlayerMP;",
         ENUM_SKY_BLOCK = "Lnet/minecraft/world/EnumSkyBlock;",
         GUI_OVERLAY_DEBUG = "Lnet/minecraft/client/gui/GuiOverlayDebug;",
@@ -54,6 +56,7 @@ public class JvmNames {
 
     // Sorted as above
     public static final String
+        BLOCK_FALLING_CAN_FALL_THROUGH = BLOCK_FALLING + "canFallThrough("+IBLOCK_STATE+")Z",
         BLOCK_POS_GETY = BLOCK_POS + "getY()I",
         CHUNK_CACHE_GET_BLOCK_STATE = CHUNK_CACHE + "getBlockState(" + BLOCK_POS + ")" + IBLOCK_STATE,
         CHUNK_GET_ENTITY_LISTS = CHUNK + "getEntityLists()[" + CLASS_INHERITANCE_MULTI_MAP,
@@ -62,11 +65,13 @@ public class JvmNames {
         COMMAND_TELEPORT_GET_ENTITY = COMMAND_TELEPORT + "getEntity(" + MINECRAFT_SERVER + ICOMMAND_SENDER + STRING + ")" + ENTITY,
         COMMAND_TP_GET_COMMAND_SENDER_AS_PLAYER = COMMAND_TP + "getCommandSenderAsPlayer(" + ICOMMAND_SENDER + ")" + ENTITY_PLAYER_MP,
         COMMAND_TP_GET_ENTITY = COMMAND_TP + "getEntity(" + MINECRAFT_SERVER + ICOMMAND_SENDER + STRING + ")" + ENTITY,
+        ENTITY_FALLING_BLOCK_CONSTRUCT = ENTITY_FALLING_BLOCK+"<init>("+WORLD+"DDD"+IBLOCK_STATE+")V",
         GUI_OVERLAY_DEBUG_CALL = GUI_OVERLAY_DEBUG + "call()Ljava/util/List;",
         WORLD_CLIENT_GET_CHUNK_FROM_BLOCK_COORDS = WORLD_CLIENT + "getChunkFromBlockCoords(" + BLOCK_POS + ")" + CHUNK,
         WORLD_GET_LIGHT_FOR = WORLD + "getLightFor(" + ENUM_SKY_BLOCK + BLOCK_POS + ")I",
         WORLD_GET_LIGHT_WITH_FLAG = WORLD + "getLight(" + BLOCK_POS + "Z)I",
         WORLD_GET_PERSISTENT_CHUNKS = WORLD + "getPersistentChunks()" + IMMUTABLE_SET_MULTIMAP,
+        WORLD_IS_AIR_BLOCK = WORLD + "isAirBlock(" + BLOCK_POS + ")Z",
         WORLD_IS_AREA_LOADED = WORLD + "isAreaLoaded(IIIIIIZ)Z";
     // @formatter:on
 }

--- a/src/main/java/cubicchunks/asm/mixin/fixes/common/MixinBlockFalling_HeightLimits.java
+++ b/src/main/java/cubicchunks/asm/mixin/fixes/common/MixinBlockFalling_HeightLimits.java
@@ -1,0 +1,95 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package cubicchunks.asm.mixin.fixes.common;
+
+import static cubicchunks.asm.JvmNames.BLOCK_POS_GETY;
+import static cubicchunks.asm.JvmNames.BLOCK_FALLING_CAN_FALL_THROUGH;
+import static cubicchunks.asm.JvmNames.ENTITY_FALLING_BLOCK_CONSTRUCT;
+import static cubicchunks.asm.JvmNames.WORLD_IS_AIR_BLOCK;
+import static cubicchunks.asm.JvmNames.WORLD;
+import static cubicchunks.asm.JvmNames.IBLOCK_STATE;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import cubicchunks.asm.MixinUtils;
+import cubicchunks.util.CubePos;
+import cubicchunks.world.ICubicWorld;
+import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockFalling;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.item.EntityFallingBlock;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+@Mixin(BlockFalling.class)
+public abstract class MixinBlockFalling_HeightLimits extends Block {
+    
+    public MixinBlockFalling_HeightLimits(Material materialIn) {
+        super(materialIn);
+    }
+    // First call - checking if BlockPos of block is > 0 to continue.
+    @Redirect(method = "checkFallable", at = @At(value = "INVOKE", target = BLOCK_POS_GETY, ordinal=0), require = 1)
+    private int checkHeightYReplace0(BlockPos pos1, World worldIn, BlockPos pos) {
+        return MixinUtils.getReplacementY(worldIn, pos1);
+    }
+
+    // Second call - creating entity on block position. Skipped.
+    // Third call - if area is not loaded call in cycle to attempt to find spot to land.
+    @Redirect(method = "checkFallable", at = @At(value = "INVOKE", target = BLOCK_POS_GETY, ordinal=2), require = 1)
+    private int checkHeightYReplace2(BlockPos pos1, World worldIn, BlockPos pos) {
+        return MixinUtils.getReplacementY(worldIn, pos1);
+    }
+
+    // Forth call - check again if founded in previous cycle spot is above 0.
+    @Redirect(method = "checkFallable", at = @At(value = "INVOKE", target = BLOCK_POS_GETY, ordinal=3), require = 1)
+    private int checkHeightYReplace3(BlockPos pos1, World worldIn, BlockPos pos) {
+        return MixinUtils.getReplacementY(worldIn, pos1);
+    }
+
+    
+    @Redirect(method = "checkFallable", at = @At(value = "INVOKE", target = BLOCK_FALLING_CAN_FALL_THROUGH), require = 2)
+    private boolean checkCanFallThrough(IBlockState blockState, World worldIn, BlockPos pos) {
+        if(((ICubicWorld)worldIn).getCubeCache().getLoadedCube(CubePos.fromBlockCoords(pos.down()))!=null) {
+            return BlockFalling.canFallThrough(blockState);
+        }
+        return false;
+    }
+    
+    @Redirect(method = "checkFallable", at = @At(value = "INVOKE", target = WORLD_IS_AIR_BLOCK), require = 2)
+    private boolean checkIsAirBlock(World worldIn, BlockPos pos) {
+        if(((ICubicWorld)worldIn).getCubeCache().getLoadedCube(CubePos.fromBlockCoords(pos))!=null) {
+            return worldIn.isAirBlock(pos);
+        }
+        return false;
+    }
+}

--- a/src/main/java/cubicchunks/debug/DebugClientProxy.java
+++ b/src/main/java/cubicchunks/debug/DebugClientProxy.java
@@ -24,6 +24,7 @@
 package cubicchunks.debug;
 
 import static cubicchunks.debug.DebugTools.itemRelightSkyBlock;
+import static cubicchunks.debug.DebugTools.itemGetLightValue;
 
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
@@ -35,9 +36,12 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class DebugClientProxy extends DebugProxy {
 
-    @Override public void initItems() {
+    @Override
+    public void initItems() {
         super.initItems();
         ModelLoader.setCustomModelResourceLocation(itemRelightSkyBlock, 0,
                 new ModelResourceLocation(itemRelightSkyBlock.getRegistryName(), "inventory"));
+        ModelLoader.setCustomModelResourceLocation(itemGetLightValue, 0,
+                new ModelResourceLocation(itemGetLightValue.getRegistryName(), "inventory"));
     }
 }

--- a/src/main/java/cubicchunks/debug/DebugProxy.java
+++ b/src/main/java/cubicchunks/debug/DebugProxy.java
@@ -25,6 +25,7 @@ package cubicchunks.debug;
 
 import static cubicchunks.debug.DebugTools.CUBIC_CHUNKS_DEBUG_TAB;
 import static cubicchunks.debug.DebugTools.itemRelightSkyBlock;
+import static cubicchunks.debug.DebugTools.itemGetLightValue;
 
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraftforge.fml.common.registry.GameRegistry;
@@ -38,5 +39,7 @@ public class DebugProxy {
     public void initItems() {
         GameRegistry.register(itemRelightSkyBlock);
         itemRelightSkyBlock.setCreativeTab(CUBIC_CHUNKS_DEBUG_TAB);
+        GameRegistry.register(itemGetLightValue);
+        itemGetLightValue.setCreativeTab(CUBIC_CHUNKS_DEBUG_TAB);
     }
 }

--- a/src/main/java/cubicchunks/debug/DebugTools.java
+++ b/src/main/java/cubicchunks/debug/DebugTools.java
@@ -23,6 +23,7 @@
  */
 package cubicchunks.debug;
 
+import cubicchunks.debug.item.GetLightValueItem;
 import cubicchunks.debug.item.RelightSkyBlockItem;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.creativetab.CreativeTabs;
@@ -44,6 +45,7 @@ public class DebugTools {
     private static DebugProxy proxy;
 
     static final Item itemRelightSkyBlock = new RelightSkyBlockItem("relight_sky_block");
+    static final Item itemGetLightValue = new GetLightValueItem("get_light_value");
 
     static final CreativeTabs CUBIC_CHUNKS_DEBUG_TAB = new CreativeTabs("cubic_chunks_debug_tab") {
         @SideOnly(Side.CLIENT) @Override public ItemStack getTabIconItem() {

--- a/src/main/resources/cubicchunks.mixins.fixes.json
+++ b/src/main/resources/cubicchunks.mixins.fixes.json
@@ -5,6 +5,7 @@
     "compatibilityLevel": "JAVA_8",
     "mixins": [
         "common.MixinEntityMinecart_KillFix",
+        "common.MixinBlockFalling_HeightLimits",
         "common.MixinEntityFallingBlock_HeightLimits",
         "common.MixinWorld"
     ],
@@ -13,3 +14,4 @@
     "server": [
     ]
 }
+


### PR DESCRIPTION
Pull request contain falling block height limits fix performed via overriding ```checkFallable(...)``` method using Mixin.
Note, that method contains unconditional ```(ICubicWorld) worldIn``` cast (is it safe?).
Also pull request contain "cube cleaner" tool, which is used for fast digging big holes in a range of loaded cubes.
Fix issue #64