### PR TITLE
World height bounds stored in NBT (second option)

### DIFF
--- a/src/main/java/cubicchunks/CommonEventHandler.java
+++ b/src/main/java/cubicchunks/CommonEventHandler.java
@@ -23,16 +23,23 @@
  */
 package cubicchunks;
 
+import cubicchunks.network.PacketDispatcher;
+import cubicchunks.network.PacketWorldHeightBounds;
 import cubicchunks.server.SpawnCubes;
 import cubicchunks.util.ReflectionUtil;
 import cubicchunks.world.ICubicWorld;
 import cubicchunks.world.ICubicWorldServer;
+import cubicchunks.world.WorldSavedDataHeightBounds;
 import cubicchunks.world.type.ICubicWorldType;
 import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.world.WorldProvider;
 import net.minecraft.world.WorldType;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerChangedDimensionEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.relauncher.Side;
 
@@ -56,10 +63,23 @@ public class CommonEventHandler {
             WorldProvider provider = ((ICubicWorldType) type).getReplacedProviderFor(world.getProvider());
             ReflectionUtil.setFieldValueSrg(world, "field_73011_w", provider);
         }
-
-        world.initCubicWorld();
-
+        int minHeight = 0;
+        int maxHeight = 255;
+        WorldSavedDataHeightBounds heightBounds = null;
         if (!world.isRemote()) {
+            heightBounds =
+                    (WorldSavedDataHeightBounds) evt.getWorld().getMapStorage().getOrLoadData(WorldSavedDataHeightBounds.class, "heightBounds");
+            if (heightBounds == null) {
+                heightBounds = new WorldSavedDataHeightBounds("heightBounds");
+            }
+            minHeight = heightBounds.minHeight;
+            maxHeight = heightBounds.maxHeight;
+        }
+        world.initCubicWorld(minHeight, maxHeight);
+        if (!world.isRemote()) {
+            heightBounds.markDirty();
+            evt.getWorld().getMapStorage().setData("heightBounds", heightBounds);
+            evt.getWorld().getMapStorage().saveAllData();
             SpawnCubes.update(world);
         }
     }
@@ -77,5 +97,11 @@ public class CommonEventHandler {
             }
         }
     }
-
+    
+    @SubscribeEvent
+    public void onPlayerJoinWorld(EntityJoinWorldEvent evt) {
+        if (evt.getEntity() instanceof EntityPlayerMP && ((ICubicWorld) evt.getWorld()).isCubicWorld()) {
+            PacketDispatcher.sendTo(new PacketWorldHeightBounds(evt.getWorld()), (EntityPlayerMP) evt.getEntity());
+        }
+    }
 }

--- a/src/main/java/cubicchunks/CubicChunks.java
+++ b/src/main/java/cubicchunks/CubicChunks.java
@@ -161,9 +161,9 @@ public class CubicChunks {
             LIGHTING_TICK_BUDGET(1, Integer.MAX_VALUE, 10,
                     "The maximum amount of time in milliseconds per tick to spend performing lighting calculations."),
             VERTICAL_CUBE_LOAD_DISTANCE(2, 32, 8, "Similar to Minecraft's view distance, only for vertical chunks."),
-            WORLD_HEIGHT_LOWER_BOUND(AddressTools.MIN_BLOCK_Y, 0, -4096,
+            DEFAULT_WORLD_HEIGHT_LOWER_BOUND(AddressTools.MIN_BLOCK_Y, 0, -4096,
                     "The lower boundary on the world. Blocks will not generate or load below this point."),
-            WORLD_HEIGHT_UPPER_BOUND(256, AddressTools.MAX_BLOCK_Y, 4096,
+            DEFAULT_WORLD_HEIGHT_UPPER_BOUND(256, AddressTools.MAX_BLOCK_Y, 4096,
                     "The upper boundary on the world. Blocks will not generate or load above this point."),
             CHUNK_G_C_INTERVAL(1, Integer.MAX_VALUE, 20 * 10,
                     "Chunk garbage collector update interval. A more lower it is - a more CPU load it will generate. "
@@ -250,11 +250,11 @@ public class CubicChunks {
         }
 
         public int getWorldHeightLowerBound() {
-            return Options.WORLD_HEIGHT_LOWER_BOUND.value;
+            return Options.DEFAULT_WORLD_HEIGHT_LOWER_BOUND.value;
         }
 
         public int getWorldHeightUpperBound() {
-            return Options.WORLD_HEIGHT_UPPER_BOUND.value;
+            return Options.DEFAULT_WORLD_HEIGHT_UPPER_BOUND.value;
         }
 
         public int getChunkGCInterval() {

--- a/src/main/java/cubicchunks/asm/mixin/core/client/MixinWorldClient.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/client/MixinWorldClient.java
@@ -49,8 +49,8 @@ public abstract class MixinWorldClient extends MixinWorld implements ICubicWorld
 
     @Shadow public abstract boolean invalidateRegionAndSetBlock(BlockPos pos, IBlockState blockState);
 
-    @Override public void initCubicWorld() {
-        super.initCubicWorld();
+    @Override public void initCubicWorld(int minHeight, int maxHeight) {
+        super.initCubicWorld(minHeight, maxHeight);
         this.isCubicWorld = true;
         CubeProviderClient cubeProviderClient = new CubeProviderClient(this);
         this.chunkProvider = cubeProviderClient;
@@ -62,6 +62,11 @@ public abstract class MixinWorldClient extends MixinWorld implements ICubicWorld
 
     @Override public CubeProviderClient getCubeCache() {
         return (CubeProviderClient) this.clientChunkProvider;
+    }
+    
+    @Override public void setHeightBounds(int minHeight1, int maxHeight1) {
+        this.minHeight = minHeight1;
+        this.maxHeight = maxHeight1;
     }
 
     @Intrinsic public boolean world$invalidateRegionAndSetBlock(BlockPos pos, IBlockState blockState) {

--- a/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorld.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorld.java
@@ -98,12 +98,12 @@ public abstract class MixinWorld implements ICubicWorld, IConfigUpdateListener {
 
     @Nullable private LightingManager lightingManager;
     protected boolean isCubicWorld;
-    private int minHeight = 0, maxHeight = 256;
+    protected int minHeight = 0, maxHeight = 256;
 
-    @Override public void initCubicWorld() {
+    @Override public void initCubicWorld(int minHeight1, int maxHeight1) {
         // Set the world height boundaries to their highest and lowest values respectively
-        this.maxHeight = CubicChunks.Config.Options.WORLD_HEIGHT_UPPER_BOUND.getValue();
-        this.minHeight = CubicChunks.Config.Options.WORLD_HEIGHT_LOWER_BOUND.getValue();
+        this.minHeight = minHeight1;
+        this.maxHeight = maxHeight1;
         //has to be created early so that creating BlankCube won't crash
         this.lightingManager = new LightingManager(this);
 

--- a/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorldServer.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorldServer.java
@@ -69,10 +69,9 @@ public abstract class MixinWorldServer extends MixinWorld implements ICubicWorld
     @Nullable private ChunkGc chunkGc;
     @Nullable private FirstLightProcessor firstLightProcessor;
 
-    @Override public void initCubicWorld() {
-        super.initCubicWorld();
+    @Override public void initCubicWorld(int minHeight, int maxHeight) {
+        super.initCubicWorld(minHeight, maxHeight);
         this.isCubicWorld = true;
-
         this.entitySpawner = new CubeWorldEntitySpawner();
 
         this.chunkProvider = new CubeProviderServer(this,

--- a/src/main/java/cubicchunks/network/ClientHandler.java
+++ b/src/main/java/cubicchunks/network/ClientHandler.java
@@ -36,6 +36,7 @@ import cubicchunks.world.cube.Cube;
 import io.netty.buffer.ByteBuf;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.INetHandler;
 import net.minecraft.network.PacketBuffer;
@@ -52,7 +53,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class ClientHandler implements INetHandler {
 
     private static final ClientHandler m_instance = new ClientHandler();
-
+    
     public static ClientHandler getInstance() {
         return m_instance;
     }
@@ -201,5 +202,14 @@ public class ClientHandler implements INetHandler {
             worldClient.invalidateRegionAndSetBlock(pos, packet.blockStates[i]);
         }
         cube.getTileEntityMap().values().forEach(TileEntity::updateContainingBlockInfo);
+    }
+
+    public void handle(final PacketWorldHeightBounds message) {
+        if (Minecraft.getMinecraft().getConnection() != null) {
+            WorldClient world = Minecraft.getMinecraft().getConnection().clientWorldController;
+            if (((ICubicWorldClient) world).isCubicWorld()) {
+                ((ICubicWorldClient) world).setHeightBounds(message.getMinHeight(), message.getMaxHeight());
+            }
+        }
     }
 }

--- a/src/main/java/cubicchunks/network/PacketDispatcher.java
+++ b/src/main/java/cubicchunks/network/PacketDispatcher.java
@@ -64,6 +64,8 @@ public class PacketDispatcher {
         registerMessage(PacketUnloadCube.Handler.class, PacketUnloadCube.class);
 
         registerMessage(PacketCubeBlockChange.Handler.class, PacketCubeBlockChange.class);
+
+        registerMessage(PacketWorldHeightBounds.Handler.class, PacketWorldHeightBounds.class);
     }
 
     /**

--- a/src/main/java/cubicchunks/network/PacketWorldHeightBounds.java
+++ b/src/main/java/cubicchunks/network/PacketWorldHeightBounds.java
@@ -1,0 +1,84 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package cubicchunks.network;
+
+import cubicchunks.world.ICubicWorld;
+import io.netty.buffer.ByteBuf;
+import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+public class PacketWorldHeightBounds implements IMessage {
+
+    private int minHeight;
+    private int maxHeight;
+
+    public PacketWorldHeightBounds() {
+    }
+
+    public PacketWorldHeightBounds(World world) {
+        this.minHeight = 0;
+        this.maxHeight = 255;
+        if(((ICubicWorld)world).isCubicWorld()) {
+            this.minHeight = ((ICubicWorld)world).getMinHeight();
+            this.maxHeight = ((ICubicWorld)world).getMaxHeight();
+        }
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        this.minHeight = buf.readInt();
+        this.maxHeight = buf.readInt();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeInt(this.minHeight);
+        buf.writeInt(this.maxHeight);
+    }
+
+    public int getMinHeight() {
+        return this.minHeight;
+    }
+
+    public int getMaxHeight() {
+        return this.maxHeight;
+    }
+
+    public static class Handler extends AbstractClientMessageHandler<PacketWorldHeightBounds> {
+
+        @Nullable @Override
+        public IMessage handleClientMessage(EntityPlayer player, PacketWorldHeightBounds message, MessageContext ctx) {
+            ClientHandler.getInstance().handle(message);
+            return null;
+        }
+    }
+}

--- a/src/main/java/cubicchunks/world/ICubicWorld.java
+++ b/src/main/java/cubicchunks/world/ICubicWorld.java
@@ -66,8 +66,10 @@ public interface ICubicWorld {
     /**
      * Initializes the world to be a CubicChunks world. Must be done before any players are online and before any chunks
      * are loaded. Cannot be used more than once.
+     * @param maxHeight 
+     * @param minHeight 
      */
-    void initCubicWorld();
+    void initCubicWorld(int minHeight, int maxHeight);
 
     boolean isCubicWorld();
 

--- a/src/main/java/cubicchunks/world/WorldSavedDataHeightBounds.java
+++ b/src/main/java/cubicchunks/world/WorldSavedDataHeightBounds.java
@@ -23,20 +23,31 @@
  */
 package cubicchunks.world;
 
-import cubicchunks.client.CubeProviderClient;
-import mcp.MethodsReturnNonnullByDefault;
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.util.math.BlockPos;
+import cubicchunks.CubicChunks;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.WorldSavedData;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+public class WorldSavedDataHeightBounds extends WorldSavedData {
 
-@ParametersAreNonnullByDefault
-@MethodsReturnNonnullByDefault
-public interface ICubicWorldClient extends ICubicWorld {
+    public int minHeight = 0, maxHeight = 256;
 
-    CubeProviderClient getCubeCache();
+    public WorldSavedDataHeightBounds(String name) {
+        super(name);
+        minHeight = CubicChunks.Config.Options.DEFAULT_WORLD_HEIGHT_LOWER_BOUND.getValue();
+        maxHeight = CubicChunks.Config.Options.DEFAULT_WORLD_HEIGHT_UPPER_BOUND.getValue();
+    }
 
-    boolean invalidateRegionAndSetBlock(BlockPos pos, IBlockState blockState);
+    @Override
+    public void readFromNBT(NBTTagCompound nbt) {
+        minHeight = nbt.getInteger("minHeight");
+        maxHeight = nbt.getInteger("maxHeight");
+    }
 
-    void setHeightBounds(int minHeight, int maxHeight);
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound compound) {
+        compound.setInteger("minHeight", minHeight);
+        compound.setInteger("maxHeight", maxHeight);
+        return compound;
+    }
+
 }

--- a/src/main/resources/META-INF/cubicchunks_at.cfg
+++ b/src/main/resources/META-INF/cubicchunks_at.cfg
@@ -33,3 +33,5 @@ protected net.minecraft.entity.EntityTrackerEntry field_73132_a # trackedEntity
 
 public net.minecraft.client.gui.GuiVideoSettings field_146501_h # optionsRowList
 public net.minecraft.client.gui.GuiOptionsRowList field_148184_k # options
+
+public net.minecraft.client.network.NetHandlerPlayClient field_147300_g # clientWorldController (WorldClient)

--- a/src/test/java/cubicchunks/TestWorldServerMixin.java
+++ b/src/test/java/cubicchunks/TestWorldServerMixin.java
@@ -93,20 +93,20 @@ public class TestWorldServerMixin {
 
     @Test
     public void testInitCubicWorldIsCubic() {
-        this.world.initCubicWorld();
+        this.world.initCubicWorld(-4096,4096);
         assertTrue(this.world.isCubicWorld());
     }
 
     @Test
     public void testCubicWorldMinHeight() {
-        this.world.initCubicWorld();
+        this.world.initCubicWorld(-4096,4096);
         assertThat(this.world.getMinHeight(), is(lessThan(0)));
     }
 
     @Test
     public void testCubicWorldMaxHeight() {
         //System.err.println(((ICubicChunksWorldType)world.getWorldInfo().getTerrainType()).getMinimumPossibleHeight());
-        this.world.initCubicWorld();
+        this.world.initCubicWorld(-4096,4096);
         assertThat(this.world.getMaxHeight(), is(greaterThan(256)));
     }
 }


### PR DESCRIPTION
Unlike 
```
Minecraft.getMinecraft().world
```
```Minecraft.getMinecraft().getConnection().clientWorldController``` is not null.