### PR TITLE
Cube specific mineable ore generator

### DIFF
--- a/src/main/java/cubicchunks/worldgen/generator/custom/features/BiomeFeatures.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/features/BiomeFeatures.java
@@ -130,7 +130,8 @@ public class BiomeFeatures {
                 getMinHeight(vanillaMinHeight),
                 getMaxHeight(vanillaMaxHeight),
                 size,
-                getProbability(vanillaMinHeight, vanillaMaxHeight)), countPerChunk);
+                getProbability(vanillaMinHeight, vanillaMaxHeight), 
+                world.getRand().nextInt()), countPerChunk);
     }
 
     protected final void addMineral(Block block, int vanillaMinHeight, int vanillaMaxHeight, int size, int countPerChunk) {


### PR DESCRIPTION
Because vanilla generator interfere with already generated cubes it ruin generated structures in dungeon generator by replacing parts of a floor with dirt and ores. This pull request will fix this.

Ores generated in a form of ideal spheres. If you want I could either add a random noise or random scale those spheres in axis (so they would shaped as ovals in section) or add additional condition so blocks will be replaced only if they are not in another virtual sphere (so they would shaped as sickle or ring in section).