### PR TITLE
Chunk 'isModified' to Cube 'isModified'

### DIFF
--- a/src/main/java/cubicchunks/asm/JvmNames.java
+++ b/src/main/java/cubicchunks/asm/JvmNames.java
@@ -74,7 +74,9 @@ public class JvmNames {
         CHUNK_GET_ENTITY_LISTS = CHUNK + "getEntityLists()[" + CLASS_INHERITANCE_MULTI_MAP,
         CHUNK_GET_TOP_FILLED_SEGMENT = CHUNK + "getTopFilledSegment()I",
         CHUNK_IS_CHUNK_LOADED = CHUNK + "isChunkLoaded:Z", // field
+        CHUNK_IS_MODIFIED = CHUNK + "isModified:Z", // field
         CHUNK_IS_POPULATED = CHUNK + "isPopulated()Z",
+        CHUNK_SET_CHUNK_MODIFIED = CHUNK + "setChunkModified()V",
         CHUNK_STORAGE_ARRAYS = CHUNK + "storageArrays:[" + EXTENDED_BLOCK_STORAGE,
         COMMAND_BASE_PARSE_DOUBLE = COMMAND_BASE + "parseDouble(D" + STRING + "IIZ)D",
         COMMAND_TELEPORT_GET_ENTITY = COMMAND_TELEPORT + "getEntity(" + MINECRAFT_SERVER + ICOMMAND_SENDER + STRING + ")" + ENTITY,

--- a/src/main/java/cubicchunks/asm/mixin/core/common/MixinChunk_Cubes.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/common/MixinChunk_Cubes.java
@@ -23,6 +23,7 @@
  */
 package cubicchunks.asm.mixin.core.common;
 
+import static cubicchunks.asm.JvmNames.CHUNK_IS_MODIFIED;
 import static cubicchunks.asm.JvmNames.CHUNK_CONSTRUCT_1;
 import static cubicchunks.asm.JvmNames.CHUNK_IS_CHUNK_LOADED;
 import static cubicchunks.asm.JvmNames.CHUNK_STORAGE_ARRAYS;
@@ -54,6 +55,7 @@ import net.minecraft.util.ReportedException;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldType;
 import net.minecraft.world.chunk.Chunk;
@@ -106,6 +108,7 @@ public abstract class MixinChunk_Cubes implements IColumn {
     @Shadow protected boolean isChunkLoaded;
     @Shadow private boolean chunkTicked;
     @Shadow private boolean isLightPopulated;
+    @Shadow private boolean isModified;
     /*
      * WARNING: WHEN YOU RENAME ANY OF THESE 3 FIELDS RENAME CORRESPONDING
      * FIELDS IN "cubicchunks.asm.mixin.core.client.MixinChunk_Cubes" and
@@ -310,7 +313,7 @@ public abstract class MixinChunk_Cubes implements IColumn {
             getCubicWorld().getLightingManager().doOnBlockSetLightUpdates(this, localX, oldHeightValue, y, localZ);
         }
     }
-
+    
     // make relightBlock no-op for cubic chunks, handles by injection above
     @Inject(method = "relightBlock", at = @At(value = "HEAD"), cancellable = true)
     private void relightBlock_CubicChunks_Replace(int x, int y, int z, CallbackInfo cbi) {
@@ -404,6 +407,15 @@ public abstract class MixinChunk_Cubes implements IColumn {
     private void setBlockState_CubicChunks_EBSSetRedirect(ExtendedBlockStorage[] array, int index, ExtendedBlockStorage val) {
         setEBS_CubicChunks(index, val);
     }
+    
+    @Redirect(method = "setBlockState", at = @At(value = "FIELD", target = CHUNK_IS_MODIFIED))
+    private void setIsModifiedFromSetBlockState_Field(Chunk chunk, boolean isModifiedIn, BlockPos pos, IBlockState state) {
+        if (isColumn) {
+            getCubicWorld().getCubeFromBlockCoords(pos).markDirty();
+        } else {
+            isModified = isModifiedIn;
+        }
+    }
 
     // ==============================================
     //                 getLightFor
@@ -438,6 +450,15 @@ public abstract class MixinChunk_Cubes implements IColumn {
     ))
     private void setLightFor_CubicChunks_EBSSetRedirect(ExtendedBlockStorage[] array, int index, ExtendedBlockStorage ebs) {
         setEBS_CubicChunks(index, ebs);
+    }
+    
+    @Redirect(method = "setLightFor", at = @At(value = "FIELD", target = CHUNK_IS_MODIFIED))
+    private void setIsModifiedFromSetLightFor_Field(Chunk chunk, boolean isModifiedIn, EnumSkyBlock type, BlockPos pos, int value) {
+        if (isColumn) {
+            getCubicWorld().getCubeFromBlockCoords(pos).markDirty();
+        } else {
+            isModified = isModifiedIn;
+        }
     }
 
     // ==============================================

--- a/src/main/java/cubicchunks/asm/mixin/core/common/MixinPlayerList.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/common/MixinPlayerList.java
@@ -1,0 +1,55 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package cubicchunks.asm.mixin.core.common;
+
+import static cubicchunks.asm.JvmNames.CHUNK_SET_CHUNK_MODIFIED;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import cubicchunks.world.ICubicWorld;
+import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.management.PlayerList;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.chunk.Chunk;
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+@Mixin(PlayerList.class)
+public abstract class MixinPlayerList {
+
+    @Redirect(method = "playerLoggedOut", at = @At(value = "INVOKE", target = CHUNK_SET_CHUNK_MODIFIED, ordinal = 0), require = 1)
+    private void setChunkModifiedOnPlayerLoggedOut(Chunk chunkIn, EntityPlayerMP playerIn) {
+        WorldServer worldserver = playerIn.getServerWorld();
+        if (((ICubicWorld) worldserver).isCubicWorld()) {
+            ((ICubicWorld) worldserver).getCubeFromCubeCoords(playerIn.chunkCoordX, playerIn.chunkCoordY, playerIn.chunkCoordZ).markDirty();
+        } else {
+            worldserver.getChunkFromChunkCoords(playerIn.chunkCoordX, playerIn.chunkCoordZ).setChunkModified();
+        }
+    }
+}

--- a/src/main/java/cubicchunks/world/cube/Cube.java
+++ b/src/main/java/cubicchunks/world/cube/Cube.java
@@ -438,9 +438,6 @@ public class Cube implements XYZAddressable {
     }
 
     @Nullable public ExtendedBlockStorage getStorage() {
-        // defensively setModified here
-        // TODO: call setModified from ExtendedBlockStorage method to save less cubes
-        this.isModified = true;
         return this.storage;
     }
 

--- a/src/main/resources/cubicchunks.mixins.core.json
+++ b/src/main/resources/cubicchunks.mixins.core.json
@@ -14,7 +14,8 @@
         "common.MixinWorld_HeightLimits",
         "common.MixinChunkCache_HeightLimits",
         "common.MixinEntity_DeathFix",
-        "common.MixinWorldProvider"
+        "common.MixinWorldProvider",
+        "common.MixinPlayerList"
     ],
     "client": [
         "client.MixinWorld_HeightLimits",


### PR DESCRIPTION
Chunk set "isModified" for Column:
generateHeightMap() - Client only
generateSkylightMap() - Cancelled
setBlockState - Redirected by me 
setLightFor - Redirected by me
setChunkModified() - not called by CubicChunks. Called by populateChunk() (not called) and PlayerList (modified by MixinPlayerList, added by me)
setModified(true) - never called