### PR TITLE
Lapis Lazuli Generation Fix - 1.11

### DIFF
--- a/src/main/java/cubicchunks/util/MathUtil.java
+++ b/src/main/java/cubicchunks/util/MathUtil.java
@@ -113,6 +113,31 @@ public class MathUtil {
                 (sqrt(2 * Math.PI) * stdDev);
     }
 
+    /**
+     * Generates a gaussian probability with the curves repeatedly positioned in a set distance to each other's center.
+     * How it works:
+     * Modulo usually works from 0 to limit-1.
+     * Since the curve is located centered on 0, it has to be moved by limit/2 to the right.
+     * This is done by substracting "halfspace" from the factor.
+     * To have the ore still generated in the area it's supposed to, the location inside the modulo gets shifted
+     * by both the mean location of the first curve and back the "halfspace".
+     * @param x Value to be evaluated
+     * @param mean Center of the first curve
+     * @param stdDev Standard deviation
+     * @param spacing Distance between the centers of the curves
+     * @return gaussian probability
+     */
+    public static double bellCurveProbabilityCyclic(int x, int mean, double stdDev, int spacing) {
+        //Using vars for better overview/easier debugging.
+        double halfSpace = (double)spacing / 2.0;
+        double shiftedLoc = (double)x - halfSpace - (double)mean;
+        double factor = Math.abs(shiftedLoc % (double)spacing) - halfSpace;
+        double divisorExp = 2.0 * stdDev * stdDev;
+        double exponent = (-1.0 * factor) * factor / divisorExp;
+        double result = exp(exponent);
+        return result;
+    }
+
     public static boolean rangesIntersect(int min1, int max1, int min2, int max2) {
         return min1 <= max2 && min2 <= max1;
     }

--- a/src/main/java/cubicchunks/worldgen/generator/custom/CustomGeneratorSettings.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/CustomGeneratorSettings.java
@@ -149,10 +149,13 @@ public class CustomGeneratorSettings {
     public float diamondOreSpawnMaxHeight = -0.75f;
 
     public int lapisLazuliSpawnSize = 7;
-    public int lapisLazuliSpawnTries = 1;
-    public float lapisLazuliSpawnProbability = 256f / 32f / (256f / Cube.SIZE);
-    public float lapisLazuliHeightMean = 0.25f; // actually vanilla closest fit is 15/64 and 7/64
-    public float lapisLazuliHeightStdDeviation = 0.125f;
+    public int lapisLazuliSpawnTries = 1; //base value to 3 to avoid extremely rare spawns
+    public float lapisLazuliSpawnProbability = 0.933307775f; //256f / 16f / (256f / Cube.SIZE);
+    public float lapisLazuliHeightMean = -1.0f; // actually vanilla closest fit is 15/64 and 7/64
+    public float lapisLazuliHeightStdDeviation = 7.1882908513f;
+    public float lapisLazuliHeightSpacing = 2.0f; //192
+    public float lapisLazuliSpawnMinHeight = Float.NEGATIVE_INFINITY;
+    public float lapisLazuliSpawnMaxHeight = -0.75f;
 
     public int hillsEmeraldOreSpawnTries = 11; // actually there are on average 5.5 attempts per chunk, so multiply prob. by 0.5
     public float hillsEmeraldOreSpawnProbability = 0.5f * 256f / 28f / (256f / Cube.SIZE);

--- a/src/main/java/cubicchunks/worldgen/generator/custom/CustomGeneratorSettings.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/CustomGeneratorSettings.java
@@ -152,7 +152,7 @@ public class CustomGeneratorSettings {
     public int lapisLazuliSpawnTries = 1; //1 try per chunk, just like vanilla
     public float lapisLazuliSpawnProbability = 0.933307775f; //resulted by approximating triangular behaviour with bell curve
     public float lapisLazuliHeightMean = -1.0f; // -> first belt at height 0
-    public float lapisLazuliHeightStdDeviation = 7.1882908513f;
+    public float lapisLazuliHeightStdDeviation = 0.11231704455f; //* 64 ~= 7.1882908513
     public float lapisLazuliHeightSpacing = 2.0f; //192
     public float lapisLazuliSpawnMinHeight = Float.NEGATIVE_INFINITY;
     public float lapisLazuliSpawnMaxHeight = -0.75f;

--- a/src/main/java/cubicchunks/worldgen/generator/custom/CustomGeneratorSettings.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/CustomGeneratorSettings.java
@@ -149,9 +149,9 @@ public class CustomGeneratorSettings {
     public float diamondOreSpawnMaxHeight = -0.75f;
 
     public int lapisLazuliSpawnSize = 7;
-    public int lapisLazuliSpawnTries = 1; //base value to 3 to avoid extremely rare spawns
-    public float lapisLazuliSpawnProbability = 0.933307775f; //256f / 16f / (256f / Cube.SIZE);
-    public float lapisLazuliHeightMean = -1.0f; // actually vanilla closest fit is 15/64 and 7/64
+    public int lapisLazuliSpawnTries = 1; //1 try per chunk, just like vanilla
+    public float lapisLazuliSpawnProbability = 0.933307775f; //resulted by approximating triangular behaviour with bell curve
+    public float lapisLazuliHeightMean = -1.0f; // -> first belt at height 0
     public float lapisLazuliHeightStdDeviation = 7.1882908513f;
     public float lapisLazuliHeightSpacing = 2.0f; //192
     public float lapisLazuliSpawnMinHeight = Float.NEGATIVE_INFINITY;

--- a/src/main/java/cubicchunks/worldgen/generator/custom/populator/DefaultDecorator.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/populator/DefaultDecorator.java
@@ -23,7 +23,7 @@
  */
 package cubicchunks.worldgen.generator.custom.populator;
 
-import static cubicchunks.worldgen.generator.custom.populator.PopulatorUtils.genOreGaussian;
+import static cubicchunks.worldgen.generator.custom.populator.PopulatorUtils.genOreBellCurve;
 import static cubicchunks.worldgen.generator.custom.populator.PopulatorUtils.genOreUniform;
 import static cubicchunks.worldgen.generator.custom.populator.PopulatorUtils.getSurfaceForCube;
 
@@ -104,9 +104,9 @@ public final class DefaultDecorator implements ICubicPopulator {
                     new WorldGenMinable(Blocks.DIAMOND_ORE.getDefaultState(), cfg.diamondOreSpawnSize),
                     cfg.diamondOreSpawnMinHeight, cfg.diamondOreSpawnMaxHeight);
 
-            genOreGaussian(world, cfg, random, pos, cfg.lapisLazuliSpawnTries, cfg.lapisLazuliSpawnProbability,
+            genOreBellCurve(world, cfg, random, pos, cfg.lapisLazuliSpawnTries, cfg.lapisLazuliSpawnProbability,
                     new WorldGenMinable(Blocks.LAPIS_ORE.getDefaultState(), cfg.lapisLazuliSpawnSize),
-                    cfg.lapisLazuliHeightMean, cfg.lapisLazuliHeightStdDeviation);
+                    cfg.lapisLazuliHeightMean, cfg.lapisLazuliHeightStdDeviation, cfg.lapisLazuliHeightSpacing, cfg.lapisLazuliSpawnMinHeight, cfg.lapisLazuliSpawnMaxHeight);
         }
     }
 

--- a/src/main/java/cubicchunks/worldgen/generator/custom/populator/PopulatorUtils.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/populator/PopulatorUtils.java
@@ -80,7 +80,7 @@ public class PopulatorUtils {
 
         int minBlockY = Math.round((float) (minY * cfg.heightFactor + cfg.heightOffset));
         int maxBlockY = Math.round((float) (maxY * cfg.heightFactor + cfg.heightOffset));
-        int iSpacing = Math.round((float) (spacing * cfg.heightFactor));
+        int iSpacing = Math.round((float) (spacing * cfg.heightFactor + cfg.heightOffset));
         int iMean = Math.round((float) (mean * cfg.heightFactor + cfg.heightOffset));
         for (int i = 0; i < count; ++i) {
             int yOffset = random.nextInt(Cube.SIZE) + Cube.SIZE / 2;

--- a/src/main/java/cubicchunks/worldgen/generator/custom/populator/PopulatorUtils.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/populator/PopulatorUtils.java
@@ -75,17 +75,23 @@ public class PopulatorUtils {
         }
     }
 
-    public static void genOreGaussian(ICubicWorld world, CustomGeneratorSettings cfg, Random random, CubePos pos,
-            int count, double probability, WorldGenerator generator, double mean, double stdDev) {
+    public static void genOreBellCurve(ICubicWorld world, CustomGeneratorSettings cfg, Random random, CubePos pos, int count,
+                                      double probability, WorldGenerator generator, double mean, double stdDev, double spacing, double minY, double maxY) {
+
+        int minBlockY = Math.round((float) (minY * cfg.heightFactor + cfg.heightOffset));
+        int maxBlockY = Math.round((float) (maxY * cfg.heightFactor + cfg.heightOffset));
+        int iSpacing = Math.round((float) (spacing * cfg.heightFactor));
+        int iMean = Math.round((float) (mean * cfg.heightFactor + cfg.heightOffset));
         for (int i = 0; i < count; ++i) {
-            if (random.nextDouble() > probability) {
-                continue;
-            }
             int yOffset = random.nextInt(Cube.SIZE) + Cube.SIZE / 2;
             int blockY = pos.getMinBlockY() + yOffset;
-            //noinspection SuspiciousNameCombination
-            double prob = MathUtil.gaussianProbabilityDensity(blockY, mean, stdDev);
-            if (random.nextDouble() > prob) {
+            //skip all potential spawns outside the spawn range
+            if((blockY > maxBlockY) || (blockY < minBlockY)){
+                continue;
+            }
+            double modifier = MathUtil.bellCurveProbabilityCyclic(blockY, iMean, stdDev, iSpacing);
+            //Modify base probability with the curve
+            if (random.nextDouble() > (probability * modifier)) {
                 continue;
             }
             int xOffset = random.nextInt(Cube.SIZE);

--- a/src/main/java/cubicchunks/worldgen/generator/custom/populator/PopulatorUtils.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/populator/PopulatorUtils.java
@@ -76,12 +76,13 @@ public class PopulatorUtils {
     }
 
     public static void genOreBellCurve(ICubicWorld world, CustomGeneratorSettings cfg, Random random, CubePos pos, int count,
-                                      double probability, WorldGenerator generator, double mean, double stdDev, double spacing, double minY, double maxY) {
+                                      double probability, WorldGenerator generator, double mean, double stdDevFactor, double spacing, double minY, double maxY) {
 
         int minBlockY = Math.round((float) (minY * cfg.heightFactor + cfg.heightOffset));
         int maxBlockY = Math.round((float) (maxY * cfg.heightFactor + cfg.heightOffset));
         int iSpacing = Math.round((float) (spacing * cfg.heightFactor + cfg.heightOffset));
         int iMean = Math.round((float) (mean * cfg.heightFactor + cfg.heightOffset));
+		double scaledStdDev = stdDevFactor * cfg.heightFactor;
         for (int i = 0; i < count; ++i) {
             int yOffset = random.nextInt(Cube.SIZE) + Cube.SIZE / 2;
             int blockY = pos.getMinBlockY() + yOffset;
@@ -89,7 +90,7 @@ public class PopulatorUtils {
             if((blockY > maxBlockY) || (blockY < minBlockY)){
                 continue;
             }
-            double modifier = MathUtil.bellCurveProbabilityCyclic(blockY, iMean, stdDev, iSpacing);
+            double modifier = MathUtil.bellCurveProbabilityCyclic(blockY, iMean, scaledStdDev, iSpacing);
             //Modify base probability with the curve
             if (random.nextDouble() > (probability * modifier)) {
                 continue;

--- a/src/main/java/cubicchunks/worldgen/gui/CustomCubicGuiUtils.java
+++ b/src/main/java/cubicchunks/worldgen/gui/CustomCubicGuiUtils.java
@@ -71,6 +71,25 @@ public class CustomCubicGuiUtils {
         wrappedSlider[0] = slider;
         return slider;
     }
+
+    public static UISlider<Float> makePositiveInfinityFloatSlider(MalisisGui gui, String name, float min, float max, float defaultVal) {
+
+        UISlider<Float>[] wrappedSlider = new UISlider[1];
+        BiPredicate<Double, Double> isInRoundRadius = getIsInRoundRadiusPredicate(wrappedSlider);
+
+        float defMult = defaultVal == 0 ? 1 : defaultVal;
+
+        Converter<Float, Float> conv = Converters.builder()
+                .linearScale(min, max).rounding().withBase(2, 1).withBase(10, 1).withBase(2, defMult).withBase(10, defMult).withMaxExp(128)
+                .withRoundingRadiusPredicate(isInRoundRadius)
+                .withInfinity().positiveAt(max)
+                .build();
+
+        UISlider<Float> slider = new UISliderNoScroll<>(gui, 100, conv, name).setValue(defaultVal);
+        wrappedSlider[0] = slider;
+        return slider;
+    }
+
     public static UISlider<Float> makeExponentialSlider(MalisisGui gui, String name, float minNeg, float maxNeg, float minPos, float maxPos,
             float defaultVal) {
 

--- a/src/main/java/cubicchunks/worldgen/gui/OreSettingsTab.java
+++ b/src/main/java/cubicchunks/worldgen/gui/OreSettingsTab.java
@@ -29,12 +29,7 @@ import static cubicchunks.worldgen.gui.CustomCubicGui.VERTICAL_INSETS;
 import static cubicchunks.worldgen.gui.CustomCubicGui.WIDTH_1_COL;
 import static cubicchunks.worldgen.gui.CustomCubicGui.WIDTH_2_COL;
 import static cubicchunks.worldgen.gui.CustomCubicGui.WIDTH_3_COL;
-import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.label;
-import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.makeFloatSlider;
-import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.makeIntSlider;
-import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.makeRangeSlider;
-import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.malisisText;
-import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.vanillaText;
+import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.*;
 
 import cubicchunks.worldgen.generator.custom.CustomGeneratorSettings;
 import cubicchunks.worldgen.gui.component.UIRangeSlider;
@@ -101,6 +96,8 @@ class OreSettingsTab {
     private final UISlider<Float> lapisLazuliOreSpawnProbability;
     private final UISlider<Float> lapisLazuliMeanHeight;
     private final UISlider<Float> lapisLazuliHeightStdDev;
+    private final UISlider<Float> lapisLazuliSpacingHeight;
+    private final UIRangeSlider<Float> lapisLazuliSpawnRange;
 
     OreSettingsTab(ExtraGui gui, CustomGeneratorSettings settings) {
         int y = -1;
@@ -246,13 +243,18 @@ class OreSettingsTab {
                 .add(this.lapisLazuliOreSpawnTries = makeIntSlider(gui, malisisText("spawn_tries", " %d"), 1, 40, settings.lapisLazuliSpawnTries),
                         new UIVerticalTableLayout.GridLocation(WIDTH_3_COL * 1, y, WIDTH_3_COL))
                 .add(this.lapisLazuliOreSpawnProbability =
-                                makeFloatSlider(gui, malisisText("spawn_probability", " %.3f"), settings.lapisLazuliSpawnProbability),
+                                makeFloatSlider(gui, malisisText("spawn_maxprobability", " %.3f"), settings.lapisLazuliSpawnProbability),
                         new UIVerticalTableLayout.GridLocation(WIDTH_3_COL * 2, y, WIDTH_3_COL))
-                .add(this.lapisLazuliMeanHeight = makeFloatSlider(gui, malisisText("mean_height", " %.3f"), -2.0f, 2.0f,
+                .add(this.lapisLazuliSpacingHeight = makePositiveInfinityFloatSlider(gui, malisisText("spacing_height", " %.3f"), -0.5f, 4.0f,
+                        settings.lapisLazuliHeightSpacing),
+                        new UIVerticalTableLayout.GridLocation(WIDTH_1_COL * 0, ++y, WIDTH_1_COL))
+                .add(this.lapisLazuliSpawnRange = makeRangeSlider(gui, vanillaText("spawn_range"), -4.0f, 4.0f, settings.lapisLazuliSpawnMinHeight,
+                        settings.lapisLazuliSpawnMaxHeight),
+                        new UIVerticalTableLayout.GridLocation(WIDTH_1_COL * 0, ++y, WIDTH_1_COL))
+                .add(this.lapisLazuliMeanHeight = makeFloatSlider(gui, malisisText("mean_height", " %.3f"), -4.0f, 4.0f,
                         settings.lapisLazuliHeightMean),
                         new UIVerticalTableLayout.GridLocation(WIDTH_2_COL * 0, ++y, WIDTH_2_COL))
-                .add(this.lapisLazuliHeightStdDev = makeFloatSlider(gui, malisisText("height_std_dev", " %.3f"), -2.0f, 2.0f,
-                        settings.lapisLazuliHeightStdDeviation),
+                .add(this.lapisLazuliHeightStdDev = makeFloatSlider(gui, malisisText("height_std_dev", " %.3f"), 1f, 10f, settings.lapisLazuliHeightStdDeviation),
                         new UIVerticalTableLayout.GridLocation(WIDTH_2_COL * 1, y, WIDTH_2_COL))
                 .init();
 
@@ -340,6 +342,9 @@ class OreSettingsTab {
         conf.lapisLazuliSpawnSize = this.lapisLazuliOreSpawnSize.getValue();
         conf.lapisLazuliHeightMean = this.lapisLazuliMeanHeight.getValue();
         conf.lapisLazuliHeightStdDeviation = this.lapisLazuliHeightStdDev.getValue();
+        conf.lapisLazuliHeightSpacing = this.lapisLazuliSpacingHeight.getValue();
+        conf.lapisLazuliSpawnMinHeight = this.lapisLazuliSpawnRange.getMinValue();
+        conf.lapisLazuliSpawnMaxHeight = this.lapisLazuliSpawnRange.getMaxValue();
 
     }
 }

--- a/src/main/java/cubicchunks/worldgen/gui/OreSettingsTab.java
+++ b/src/main/java/cubicchunks/worldgen/gui/OreSettingsTab.java
@@ -260,7 +260,7 @@ class OreSettingsTab {
                 .add(this.lapisLazuliMeanHeight = makeFloatSlider(gui, malisisText("mean_height", " %.3f"), -4.0f, 4.0f,
                         settings.lapisLazuliHeightMean),
                         new UIVerticalTableLayout.GridLocation(WIDTH_2_COL * 0, ++y, WIDTH_2_COL))
-                .add(this.lapisLazuliHeightStdDev = makeFloatSlider(gui, malisisText("height_std_dev", " %.3f"), 1f, 10f, settings.lapisLazuliHeightStdDeviation),
+                .add(this.lapisLazuliHeightStdDev = makeFloatSlider(gui, malisisText("height_std_dev", " %.3f"), 0f, 1f, settings.lapisLazuliHeightStdDeviation),
                         new UIVerticalTableLayout.GridLocation(WIDTH_2_COL * 1, y, WIDTH_2_COL))
                 .init();
 

--- a/src/main/java/cubicchunks/worldgen/gui/OreSettingsTab.java
+++ b/src/main/java/cubicchunks/worldgen/gui/OreSettingsTab.java
@@ -29,7 +29,13 @@ import static cubicchunks.worldgen.gui.CustomCubicGui.VERTICAL_INSETS;
 import static cubicchunks.worldgen.gui.CustomCubicGui.WIDTH_1_COL;
 import static cubicchunks.worldgen.gui.CustomCubicGui.WIDTH_2_COL;
 import static cubicchunks.worldgen.gui.CustomCubicGui.WIDTH_3_COL;
-import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.*;
+import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.label;
+import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.makeFloatSlider;
+import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.makeIntSlider;
+import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.makeRangeSlider;
+import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.makePositiveInfinityFloatSlider;
+import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.malisisText;
+import static cubicchunks.worldgen.gui.CustomCubicGuiUtils.vanillaText;
 
 import cubicchunks.worldgen.generator.custom.CustomGeneratorSettings;
 import cubicchunks.worldgen.gui.component.UIRangeSlider;

--- a/src/main/resources/assets/cubicchunks/lang/en_US.lang
+++ b/src/main/resources/assets/cubicchunks/lang/en_US.lang
@@ -8,9 +8,6 @@ itemGroup.cubic_chunks_debug_tab=Cubic Chunks debug items
 ###        general gui        ###
 #################################
 
-cubicchunks.gui.worldmenu.cc_enable=CubicChunks: Yes
-cubicchunks.gui.worldmenu.cc_disable=CubicChunks: No
-
 cubicchunks.gui.customcubic.previous_page=Previous
 cubicchunks.gui.customcubic.next_page=Next
 cubicchunks.gui.customcubic.done=Done
@@ -88,10 +85,12 @@ cubicchunks.gui.customcubic.lapis_lazuli_ore_group=Lapis Lazuli Ore:
 cubicchunks.gui.customcubic.spawn_size=Spawn Size:
 cubicchunks.gui.customcubic.spawn_tries=Spawn Tries:
 cubicchunks.gui.customcubic.spawn_probability=Probability:
+cubicchunks.gui.customcubic.spawn_maxprobability=Max. Probability:
 cubicchunks.gui.customcubic.spawn_range=Height %.2f%%%% to %.2f%%%%
 
-cubicchunks.gui.customcubic.mean_height=Mean Height:
+cubicchunks.gui.customcubic.mean_height=Center of first Belt:
 cubicchunks.gui.customcubic.height_std_dev=Height Std. Deviation:
+cubicchunks.gui.customcubic.spacing_height=Height Spacing:
 #################################
 ### advanced terrain settings ###
 #################################

--- a/src/main/resources/assets/cubicchunks/lang/en_US.lang
+++ b/src/main/resources/assets/cubicchunks/lang/en_US.lang
@@ -8,6 +8,9 @@ itemGroup.cubic_chunks_debug_tab=Cubic Chunks debug items
 ###        general gui        ###
 #################################
 
+cubicchunks.gui.worldmenu.cc_enable=CubicChunks: Yes
+cubicchunks.gui.worldmenu.cc_disable=CubicChunks: No
+
 cubicchunks.gui.customcubic.previous_page=Previous
 cubicchunks.gui.customcubic.next_page=Next
 cubicchunks.gui.customcubic.done=Done
@@ -86,11 +89,13 @@ cubicchunks.gui.customcubic.spawn_size=Spawn Size:
 cubicchunks.gui.customcubic.spawn_tries=Spawn Tries:
 cubicchunks.gui.customcubic.spawn_probability=Probability:
 cubicchunks.gui.customcubic.spawn_maxprobability=Max. Probability:
+
 cubicchunks.gui.customcubic.spawn_range=Height %.2f%%%% to %.2f%%%%
 
 cubicchunks.gui.customcubic.mean_height=Center of first Belt:
 cubicchunks.gui.customcubic.height_std_dev=Height Std. Deviation:
 cubicchunks.gui.customcubic.spacing_height=Height Spacing:
+
 #################################
 ### advanced terrain settings ###
 #################################

--- a/src/main/resources/assets/cubicchunks/lang/en_US.lang
+++ b/src/main/resources/assets/cubicchunks/lang/en_US.lang
@@ -93,7 +93,7 @@ cubicchunks.gui.customcubic.spawn_maxprobability=Max. Probability:
 cubicchunks.gui.customcubic.spawn_range=Height %.2f%%%% to %.2f%%%%
 
 cubicchunks.gui.customcubic.mean_height=Center of first Belt:
-cubicchunks.gui.customcubic.height_std_dev=Height Std. Deviation:
+cubicchunks.gui.customcubic.height_std_dev=Height Std. Dev. Factor:
 cubicchunks.gui.customcubic.spacing_height=Height Spacing:
 
 #################################


### PR DESCRIPTION
First: please close the old PR, the commits in this are cleaner, and a lot has been changed anyways.

The code was tweaked to generate Lapis Lazuli in "ore belts" of which the distance to each other can be adjusted.

The distance setting style has been changed to fit all other settings and the methods have been renamed to signify that no true gaussian distribution formula is used.