### PR TITLE
Cube.SIZE Clean Up

### DIFF
--- a/src/main/java/cubicchunks/asm/mixin/core/client/MixinViewFrustum_RenderHeightFix.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/client/MixinViewFrustum_RenderHeightFix.java
@@ -24,6 +24,7 @@
 package cubicchunks.asm.mixin.core.client;
 
 import cubicchunks.world.ICubicWorld;
+import cubicchunks.world.cube.Cube;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ViewFrustum;
@@ -72,13 +73,13 @@ public class MixinViewFrustum_RenderHeightFix {
         double z = view.posZ;
 
         // treat the y dimension the same as all the rest
-        int viewX = MathHelper.floor(x) - 8;
-        int viewY = MathHelper.floor(y) - 8;
-        int viewZ = MathHelper.floor(z) - 8;
+        int viewX = MathHelper.floor(x) - Cube.SIZE / 2;
+        int viewY = MathHelper.floor(y) - Cube.SIZE / 2;
+        int viewZ = MathHelper.floor(z) - Cube.SIZE / 2;
 
-        int xSizeInBlocks = this.countChunksX * 16;
-        int ySizeInBlocks = this.countChunksY * 16;
-        int zSizeInBlocks = this.countChunksZ * 16;
+        int xSizeInBlocks = this.countChunksX * Cube.SIZE;
+        int ySizeInBlocks = this.countChunksY * Cube.SIZE;
+        int zSizeInBlocks = this.countChunksZ * Cube.SIZE;
 
         for (int xIndex = 0; xIndex < this.countChunksX; xIndex++) {
             //getRendererBlockCoord
@@ -111,9 +112,9 @@ public class MixinViewFrustum_RenderHeightFix {
             return;
         }
         // treat the y dimension the same as all the rest
-        int x = MathHelper.intFloorDiv(pos.getX(), 16);
-        int y = MathHelper.intFloorDiv(pos.getY(), 16);
-        int z = MathHelper.intFloorDiv(pos.getZ(), 16);
+        int x = MathHelper.intFloorDiv(pos.getX(), Cube.SIZE);
+        int y = MathHelper.intFloorDiv(pos.getY(), Cube.SIZE);
+        int z = MathHelper.intFloorDiv(pos.getZ(), Cube.SIZE);
         x %= this.countChunksX;
         if (x < 0) {
             x += this.countChunksX;

--- a/src/main/java/cubicchunks/asm/mixin/core/common/MixinChunk_Cubes.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/common/MixinChunk_Cubes.java
@@ -347,10 +347,10 @@ public abstract class MixinChunk_Cubes implements IColumn {
             try {
                 //if (y >= 0 && y >> 4 < this.storageArrays.length)
                 {
-                    ExtendedBlockStorage extendedblockstorage = getEBS_CubicChunks(y >> 4);
+                    ExtendedBlockStorage extendedblockstorage = getEBS_CubicChunks(blockToCube(y));
 
                     if (extendedblockstorage != NULL_BLOCK_STORAGE) {
-                        return extendedblockstorage.get(x & 15, y & 15, z & 15);
+                        return extendedblockstorage.get(blockToLocal(x), blockToLocal(y), blockToLocal(z));
                     }
                 }
 
@@ -481,7 +481,7 @@ public abstract class MixinChunk_Cubes implements IColumn {
             entityIn.setDead();
         }
 
-        int k = MathHelper.floor(entityIn.posY / 16.0D);
+        int k = MathHelper.floor(entityIn.posY / Cube.SIZE_D);
 
         if (k < Coords.blockToCube(getCubicWorld().getMinHeight())) {
             k = Coords.blockToCube(getCubicWorld().getMinHeight());
@@ -605,8 +605,8 @@ public abstract class MixinChunk_Cubes implements IColumn {
         }
         cbi.cancel();
 
-        int minY = MathHelper.floor((aabb.minY - World.MAX_ENTITY_RADIUS) / 16.0D);
-        int maxY = MathHelper.floor((aabb.maxY + World.MAX_ENTITY_RADIUS) / 16.0D);
+        int minY = MathHelper.floor((aabb.minY - World.MAX_ENTITY_RADIUS) / Cube.SIZE_D);
+        int maxY = MathHelper.floor((aabb.maxY + World.MAX_ENTITY_RADIUS) / Cube.SIZE_D);
         minY = MathHelper.clamp(minY,
                 blockToCube(getCubicWorld().getMinHeight()),
                 blockToCube(getCubicWorld().getMaxHeight()));
@@ -652,8 +652,8 @@ public abstract class MixinChunk_Cubes implements IColumn {
         }
         cbi.cancel();
 
-        int minY = MathHelper.floor((aabb.minY - World.MAX_ENTITY_RADIUS) / 16.0D);
-        int maxY = MathHelper.floor((aabb.maxY + World.MAX_ENTITY_RADIUS) / 16.0D);
+        int minY = MathHelper.floor((aabb.minY - World.MAX_ENTITY_RADIUS) / Cube.SIZE_D);
+        int maxY = MathHelper.floor((aabb.maxY + World.MAX_ENTITY_RADIUS) / Cube.SIZE_D);
         minY = MathHelper.clamp(minY,
                 blockToCube(getCubicWorld().getMinHeight()),
                 blockToCube(getCubicWorld().getMaxHeight()));
@@ -715,8 +715,8 @@ public abstract class MixinChunk_Cubes implements IColumn {
             endY = getCubicWorld().getMaxHeight() - 1;
         }
 
-        for (int i = startY; i <= endY; i += 16) {
-            ExtendedBlockStorage extendedblockstorage = getEBS_CubicChunks(i >> 4);
+        for (int i = startY; i <= endY; i += Cube.SIZE) {
+            ExtendedBlockStorage extendedblockstorage = getEBS_CubicChunks(blockToCube(i));
 
             if (extendedblockstorage != NULL_BLOCK_STORAGE && !extendedblockstorage.isEmpty()) {
                 return false;

--- a/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorld.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorld.java
@@ -250,7 +250,7 @@ public abstract class MixinWorld implements ICubicWorld {
     }
 
     @Override public boolean isBlockColumnLoaded(BlockPos pos, boolean allowEmpty) {
-        return this.isChunkLoaded(pos.getX() >> 4, pos.getZ() >> 4, allowEmpty);
+        return this.isChunkLoaded(blockToCube(pos.getX()), blockToCube(pos.getZ()), allowEmpty);
     }
 
     //vanilla methods

--- a/src/main/java/cubicchunks/asm/mixin/fixes/common/MixinTileEntityEndGateway.java
+++ b/src/main/java/cubicchunks/asm/mixin/fixes/common/MixinTileEntityEndGateway.java
@@ -27,6 +27,7 @@ import static cubicchunks.asm.JvmNames.CHUNK_GET_TOP_FILLED_SEGMENT;
 
 import cubicchunks.asm.JvmNames;
 import cubicchunks.world.column.IColumn;
+import cubicchunks.world.cube.Cube;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.tileentity.TileEntityEndGateway;
 import net.minecraft.util.math.MathHelper;
@@ -69,7 +70,7 @@ public class MixinTileEntityEndGateway {
      */
     @Overwrite
     private static Chunk getChunk(World world, Vec3d pos) {
-        Chunk chunk = world.getChunkFromChunkCoords(MathHelper.floor(pos.x / 16.0D), MathHelper.floor(pos.z / 16.0D));
+        Chunk chunk = world.getChunkFromChunkCoords(MathHelper.floor(pos.x / Cube.SIZE_D), MathHelper.floor(pos.z / Cube.SIZE_D));
         if (((IColumn) chunk).getCubicWorld().isCubicWorld()) {
             for (int cubeY = 0; cubeY < 16; cubeY++) {
                 ((IColumn) chunk).getCube(cubeY);// load the cube

--- a/src/main/java/cubicchunks/asm/mixin/noncritical/common/command/MixinCommandFill.java
+++ b/src/main/java/cubicchunks/asm/mixin/noncritical/common/command/MixinCommandFill.java
@@ -29,6 +29,7 @@ import static cubicchunks.asm.JvmNames.WORLD_IS_BLOCK_LOADED;
 
 import cubicchunks.asm.MixinUtils;
 import cubicchunks.world.ICubicWorld;
+import cubicchunks.world.cube.Cube;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -103,7 +104,7 @@ public class MixinCommandFill {
             //if the above injection somehow fails, fall back to something reasonable
             return ((ICubicWorld) world).isBlockColumnLoaded(pos);
         }
-        for (int blockY = minY; blockY <= maxY; blockY += 16) {
+        for (int blockY = minY; blockY <= maxY; blockY += Cube.SIZE) {
             if (!world.isBlockLoaded(new BlockPos(pos.getX(), blockY, pos.getZ()))) {
                 return false;
             }

--- a/src/main/java/cubicchunks/debug/DebugWorldType.java
+++ b/src/main/java/cubicchunks/debug/DebugWorldType.java
@@ -95,8 +95,8 @@ public class DebugWorldType extends WorldType implements ICubicWorldType {
                     double currDensity = perlin.getValue(pos.getX(), pos.getY() * 0.5, pos.getZ());
                     double aboveDensity = perlin.getValue(pos.getX(), (pos.getY() + 1) * 0.5, pos.getZ());
                     if (cubeY >= 16) {
-                        currDensity -= (pos.getY() - 16 * 16) / 100;
-                        aboveDensity -= (pos.getY() + 1 - 16 * 16) / 100;
+                        currDensity -= (pos.getY() - Cube.SIZE * Cube.SIZE) / 100;
+                        aboveDensity -= (pos.getY() + 1 - Cube.SIZE * Cube.SIZE) / 100;
                     }
                     if (currDensity > 0.5) {
                         if (currDensity > 0.5 && aboveDensity <= 0.5) {

--- a/src/main/java/cubicchunks/lighting/FirstLightProcessor.java
+++ b/src/main/java/cubicchunks/lighting/FirstLightProcessor.java
@@ -157,8 +157,8 @@ public class FirstLightProcessor {
         ICubicWorld world = cube.getCubicWorld();
 
         // Cache min/max Y, generating them may be expensive
-        int[][] minBlockYArr = new int[16][16];
-        int[][] maxBlockYArr = new int[16][16];
+        int[][] minBlockYArr = new int[Cube.SIZE][Cube.SIZE];
+        int[][] maxBlockYArr = new int[Cube.SIZE][Cube.SIZE];
 
         int minBlockX = cubeToMinBlock(cube.getX());
         int maxBlockX = cubeToMaxBlock(cube.getX());

--- a/src/main/java/cubicchunks/lighting/SkyLightUpdateCubeSelector.java
+++ b/src/main/java/cubicchunks/lighting/SkyLightUpdateCubeSelector.java
@@ -85,7 +85,7 @@ class SkyLightUpdateCubeSelector {
         //attempt to update lighting only in loaded cubes
         for (Cube cube : column.getLoadedCubes()) {
             int cubeY = cube.getY();
-            int minCubeBlockY = cubeY * 16;
+            int minCubeBlockY = cubeY * Cube.SIZE;
 
             //do we even need to do anything here?
             if (maxBlockY < minCubeBlockY) {

--- a/src/main/java/cubicchunks/network/PacketCubeBlockChange.java
+++ b/src/main/java/cubicchunks/network/PacketCubeBlockChange.java
@@ -23,6 +23,8 @@
  */
 package cubicchunks.network;
 
+import static cubicchunks.util.Coords.blockToCube;
+import static cubicchunks.util.Coords.blockToLocal;
 import static net.minecraftforge.fml.common.network.ByteBufUtils.readVarInt;
 
 import cubicchunks.util.AddressTools;
@@ -68,14 +70,14 @@ public class PacketCubeBlockChange implements IMessage {
             int y = AddressTools.getLocalY(localAddress);
             int z = AddressTools.getLocalZ(localAddress);
             this.blockStates[i] = cube.getBlockState(x, y, z);
-            xzAddresses.add(x | z << 4);
+            xzAddresses.add(AddressTools.getLocalAddress(x, z));
         }
         this.heightValues = new int[xzAddresses.size()];
         i = 0;
         TIntIterator it = xzAddresses.iterator();
         while (it.hasNext()) {
             int v = it.next();
-            int height = cube.getColumn().getOpacityIndex().getTopBlockY(v & 0xF, v >> 4);
+            int height = cube.getColumn().getOpacityIndex().getTopBlockY(blockToLocal(v), blockToCube(v));
             v |= height << 8;
             heightValues[i] = v;
             i++;

--- a/src/main/java/cubicchunks/network/WorldEncoder.java
+++ b/src/main/java/cubicchunks/network/WorldEncoder.java
@@ -82,7 +82,7 @@ class WorldEncoder {
         cubes.forEach(cube -> {
             if (!cube.isEmpty()) {
                 byte[] heightmaps = ((ServerHeightMap) cube.getColumn().getOpacityIndex()).getDataForClient();
-                assert heightmaps.length == 256 * Integer.BYTES;
+                assert heightmaps.length == Cube.SIZE * Cube.SIZE * Integer.BYTES;
                 out.writeBytes(heightmaps);
             }
         });
@@ -149,7 +149,7 @@ class WorldEncoder {
         for (int i = 0; i < cubes.size(); i++) {
             if (!isEmpty[i]) {
                 Cube cube = cubes.get(i);
-                byte[] heightmaps = new byte[256 * Integer.BYTES];
+                byte[] heightmaps = new byte[Cube.SIZE * Cube.SIZE * Integer.BYTES];
                 in.readBytes(heightmaps);
                 ClientHeightMap coi = ((ClientHeightMap) cube.getColumn().getOpacityIndex());
                 coi.setData(heightmaps);

--- a/src/main/java/cubicchunks/server/chunkio/IONbtReader.java
+++ b/src/main/java/cubicchunks/server/chunkio/IONbtReader.java
@@ -91,7 +91,7 @@ public class IONbtReader {
     }
 
     private static void readBiomes(NBTTagCompound nbt, IColumn column) {// biomes
-        System.arraycopy(nbt.getByteArray("Biomes"), 0, column.getBiomeArray(), 0, 256);
+        System.arraycopy(nbt.getByteArray("Biomes"), 0, column.getBiomeArray(), 0, Cube.SIZE * Cube.SIZE);
     }
 
     private static void readOpacityIndex(NBTTagCompound nbt, IColumn IColumn) {// biomes

--- a/src/main/java/cubicchunks/util/CubePos.java
+++ b/src/main/java/cubicchunks/util/CubePos.java
@@ -252,9 +252,9 @@ public class CubePos {
 
     public BlockPos randomPopulationPos(Random rand) {
         return new BlockPos(
-                rand.nextInt(16) + getXCenter(),
-                rand.nextInt(16) + getYCenter(),
-                rand.nextInt(16) + getZCenter());
+                rand.nextInt(Cube.SIZE) + getXCenter(),
+                rand.nextInt(Cube.SIZE) + getYCenter(),
+                rand.nextInt(Cube.SIZE) + getZCenter());
     }
 
     public CubePos above() {

--- a/src/main/java/cubicchunks/util/StructureGenUtil.java
+++ b/src/main/java/cubicchunks/util/StructureGenUtil.java
@@ -23,6 +23,7 @@
  */
 package cubicchunks.util;
 
+import cubicchunks.world.cube.Cube;
 import cubicchunks.worldgen.generator.ICubePrimer;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.state.IBlockState;
@@ -91,20 +92,20 @@ public class StructureGenUtil {
         if (boundingBox.minX < 0) {
             boundingBox.minX = 0;
         }
-        if (boundingBox.maxX > 16) {
-            boundingBox.maxX = 16;
+        if (boundingBox.maxX > Cube.SIZE) {
+            boundingBox.maxX = Cube.SIZE;
         }
         if (boundingBox.minY < 0) {
             boundingBox.minY = 0;
         }
-        if (boundingBox.maxY > 16) {
-            boundingBox.maxY = 16;
+        if (boundingBox.maxY > Cube.SIZE) {
+            boundingBox.maxY = Cube.SIZE;
         }
         if (boundingBox.minZ < 0) {
             boundingBox.minZ = 0;
         }
-        if (boundingBox.maxZ > 16) {
-            boundingBox.maxZ = 16;
+        if (boundingBox.maxZ > Cube.SIZE) {
+            boundingBox.maxZ = Cube.SIZE;
         }
     }
 }

--- a/src/main/java/cubicchunks/world/ClientHeightMap.java
+++ b/src/main/java/cubicchunks/world/ClientHeightMap.java
@@ -127,7 +127,7 @@ public class ClientHeightMap implements IHeightMap {
             ByteArrayInputStream buf = new ByteArrayInputStream(data);
             DataInputStream in = new DataInputStream(buf);
 
-            for (int i = 0; i < 256; i++) {
+            for (int i = 0; i < Cube.SIZE * Cube.SIZE; i++) {
                 hmap.set(i, in.readInt());
             }
 

--- a/src/main/java/cubicchunks/world/CubeWorldEntitySpawner.java
+++ b/src/main/java/cubicchunks/world/CubeWorldEntitySpawner.java
@@ -242,14 +242,14 @@ public class CubeWorldEntitySpawner extends WorldEntitySpawner {
     }
 
     private static BlockPos getRandomChunkPosition(ICubicWorldServer world, CubePos pos) {
-        int blockX = pos.getMinBlockX() + world.getRand().nextInt(16);
-        int blockZ = pos.getMinBlockZ() + world.getRand().nextInt(16);
+        int blockX = pos.getMinBlockX() + world.getRand().nextInt(Cube.SIZE);
+        int blockZ = pos.getMinBlockZ() + world.getRand().nextInt(Cube.SIZE);
 
         int height = world.getEffectiveHeight(blockX, blockZ);
         if (pos.getMinBlockY() > height) {
             return null;
         }
-        int blockY = pos.getMinBlockY() + world.getRand().nextInt(16);
+        int blockY = pos.getMinBlockY() + world.getRand().nextInt(Cube.SIZE);
         return new BlockPos(blockX, blockY, blockZ);
     }
 

--- a/src/main/java/cubicchunks/world/FastCubeWorldEntitySpawner.java
+++ b/src/main/java/cubicchunks/world/FastCubeWorldEntitySpawner.java
@@ -104,9 +104,9 @@ public class FastCubeWorldEntitySpawner extends WorldEntitySpawner {
                 // If we found nice spawnpoint in this attempt we will raise
                 // 'maxSpawnAttempts' and 'maxPackSize' values.
                 for (int spawnAttempt = 0; spawnAttempt < maxSpawnAttempts && spawned <= maxPackSize; spawnAttempt++) {
-                    int blockX = minBlockX + rand.nextInt(16);
-                    int blockY = minBlockY + rand.nextInt(16);
-                    int blockZ = minBlockZ + rand.nextInt(16);
+                    int blockX = minBlockX + rand.nextInt(Cube.SIZE);
+                    int blockY = minBlockY + rand.nextInt(Cube.SIZE);
+                    int blockZ = minBlockZ + rand.nextInt(Cube.SIZE);
                     int height = world.getEffectiveHeight(blockX, blockZ) + 1;
                     if (minBlockY > height) {
                         blockY = height;

--- a/src/main/java/cubicchunks/world/SpawnPlaceFinder.java
+++ b/src/main/java/cubicchunks/world/SpawnPlaceFinder.java
@@ -24,6 +24,7 @@
 package cubicchunks.world;
 
 import cubicchunks.CubicChunks;
+import cubicchunks.world.cube.Cube;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
@@ -106,7 +107,7 @@ public class SpawnPlaceFinder {
 
     private BlockPos findMinPos(Chunk chunk, BlockPos pos) {
         // go down twice as much each time until we hit filled space
-        int dy = 16;
+        int dy = Cube.SIZE;
         BlockPos p;
         while ((p = findNonEmpty(chunk, pos.down(dy))) == null) {
             dy *= 2;
@@ -120,7 +121,7 @@ public class SpawnPlaceFinder {
 
     private BlockPos findMaxPos(Chunk chunk, BlockPos pos) {
         // go up twice as much each time until we hit filled space
-        int dy = 16;
+        int dy = Cube.SIZE;
         BlockPos p;
         while ((p = findEmpty(chunk, pos.up(dy))) == null) {
             dy *= 2;

--- a/src/main/java/cubicchunks/world/cube/Cube.java
+++ b/src/main/java/cubicchunks/world/cube/Cube.java
@@ -23,19 +23,14 @@
  */
 package cubicchunks.world.cube;
 
-import static cubicchunks.util.Coords.blockToLocal;
-import static cubicchunks.util.Coords.localToBlock;
-
 import cubicchunks.CubicChunks;
 import cubicchunks.lighting.LightingManager;
 import cubicchunks.util.AddressTools;
-import cubicchunks.util.Coords;
 import cubicchunks.util.CubePos;
 import cubicchunks.util.XYZAddressable;
 import cubicchunks.util.ticket.TicketList;
 import cubicchunks.world.EntityContainer;
 import cubicchunks.world.ICubicWorld;
-import cubicchunks.world.ICubicWorldServer;
 import cubicchunks.world.IHeightMap;
 import cubicchunks.world.column.IColumn;
 import cubicchunks.worldgen.generator.ICubePrimer;
@@ -47,15 +42,12 @@ import net.minecraft.entity.Entity;
 import net.minecraft.init.Blocks;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.NextTickListEntry;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -63,8 +55,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.BooleanSupplier;
@@ -76,6 +66,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.logging.log4j.LogManager;
 
 import com.google.common.collect.Sets;
+
+import static cubicchunks.util.Coords.*;
 
 /**
  * A cube is our extension of minecraft's chunk system to three dimensions. Each cube encloses a cubic area in the world
@@ -93,6 +85,9 @@ public class Cube implements XYZAddressable {
      * Side length of a cube
      */
     public static final int SIZE = 16;
+
+    public static final double SIZE_D = 16.0D;
+
 
     /**
      * Tickets keep this chunk loaded and ticking. See the docs of {@link TicketList} and {@link
@@ -194,13 +189,13 @@ public class Cube implements XYZAddressable {
     public Cube(IColumn column, int cubeY, ICubePrimer primer) {
         this(column, cubeY);
 
-        int miny = Coords.cubeToMinBlock(cubeY);
+        int miny = cubeToMinBlock(cubeY);
         IHeightMap opindex = column.getOpacityIndex();
 
-        for (int x = 0; x < 16; x++) {
-            for (int z = 0; z < 16; z++) {
+        for (int x = 0; x < Cube.SIZE; x++) {
+            for (int z = 0; z < Cube.SIZE; z++) {
 
-                for (int y = 15; y >= 0; y--) {
+                for (int y = Cube.SIZE - 1; y >= 0; y--) {
                     IBlockState newstate = primer.getBlockState(x, y, z);
 
                     if (newstate.getMaterial() != Material.AIR) {
@@ -394,7 +389,7 @@ public class Cube implements XYZAddressable {
             if (ntle.scheduledTime > world.getTotalWorldTime())
                 return;
             BlockPos pos = ntle.position;
-            IBlockState iblockstate = this.storage.get(pos.getX() & 15, pos.getY() & 15, pos.getZ() & 15);
+            IBlockState iblockstate = this.storage.get(blockToLocal(pos.getX()), blockToLocal(pos.getY()), blockToLocal(pos.getZ()));
             if (iblockstate.getMaterial() != Material.AIR && iblockstate.getBlock() == ntle.getBlock()) {
                 iblockstate.getBlock().updateTick((WorldServer) world, ntle.position, iblockstate, rand);
             }
@@ -417,9 +412,9 @@ public class Cube implements XYZAddressable {
     public void randomTick(WorldServer worldServer, Random rand) {
         this.updateLCG = this.updateLCG * 3 + 1013904223;
         int j1 = updateLCG >> 2;
-        int localX = j1 & 15;
-        int localY = j1 >> 8 & 15;
-        int localZ = j1 >> 16 & 15;
+        int localX = AddressTools.getLocalX(j1);
+        int localY = AddressTools.getLocalY(j1);
+        int localZ = AddressTools.getLocalZ(j1);
         IBlockState iblockstate = this.storage.get(localX, localY, localZ);
         Block block = iblockstate.getBlock();
         if (block.getTickRandomly()) {
@@ -463,9 +458,9 @@ public class Cube implements XYZAddressable {
      * @return the block position
      */
     public BlockPos localAddressToBlockPos(int localAddress) {
-        int x = Coords.localToBlock(this.coords.getX(), AddressTools.getLocalX(localAddress));
-        int y = Coords.localToBlock(this.coords.getY(), AddressTools.getLocalY(localAddress));
-        int z = Coords.localToBlock(this.coords.getZ(), AddressTools.getLocalZ(localAddress));
+        int x = localToBlock(this.coords.getX(), AddressTools.getLocalX(localAddress));
+        int y = localToBlock(this.coords.getY(), AddressTools.getLocalY(localAddress));
+        int z = localToBlock(this.coords.getZ(), AddressTools.getLocalZ(localAddress));
         return new BlockPos(x, y, z);
     }
 
@@ -525,9 +520,9 @@ public class Cube implements XYZAddressable {
      * @return <code>true</code> if the position is within this cube, <code>false</code> otherwise
      */
     public boolean containsBlockPos(BlockPos blockPos) {
-        return this.coords.getX() == Coords.blockToCube(blockPos.getX())
-                && this.coords.getY() == Coords.blockToCube(blockPos.getY())
-                && this.coords.getZ() == Coords.blockToCube(blockPos.getZ());
+        return this.coords.getX() == blockToCube(blockPos.getX())
+                && this.coords.getY() == blockToCube(blockPos.getY())
+                && this.coords.getZ() == blockToCube(blockPos.getZ());
     }
 
     @Nullable public ExtendedBlockStorage getStorage() {
@@ -540,7 +535,7 @@ public class Cube implements XYZAddressable {
     }
 
     private void newStorage() {
-        storage = new ExtendedBlockStorage(Coords.cubeToMinBlock(getY()), world.getProvider().hasSkyLight());
+        storage = new ExtendedBlockStorage(cubeToMinBlock(getY()), world.getProvider().hasSkyLight());
     }
 
     /**
@@ -639,8 +634,8 @@ public class Cube implements XYZAddressable {
 
     public void markForRenderUpdate() {
         this.world.markBlockRangeForRenderUpdate(
-                Coords.cubeToMinBlock(this.coords.getX()), Coords.cubeToMinBlock(this.coords.getY()), Coords.cubeToMinBlock(this.coords.getZ()),
-                Coords.cubeToMaxBlock(this.coords.getX()), Coords.cubeToMaxBlock(this.coords.getY()), Coords.cubeToMaxBlock(this.coords.getZ())
+                cubeToMinBlock(this.coords.getX()), cubeToMinBlock(this.coords.getY()), cubeToMinBlock(this.coords.getZ()),
+                cubeToMaxBlock(this.coords.getX()), cubeToMaxBlock(this.coords.getY()), cubeToMaxBlock(this.coords.getZ())
         );
     }
 

--- a/src/main/java/cubicchunks/worldgen/generator/custom/populator/SurfaceSnowPopulator.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/populator/SurfaceSnowPopulator.java
@@ -41,8 +41,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class SurfaceSnowPopulator implements ICubicPopulator {
 
     @Override public void generate(ICubicWorld world, Random random, CubePos pos, CubicBiome biome) {
-        for (int dx = 0; dx < 16; ++dx) {
-            for (int dz = 0; dz < 16; ++dz) {
+        for (int dx = 0; dx < Cube.SIZE; ++dx) {
+            for (int dz = 0; dz < Cube.SIZE; ++dz) {
                 int xOffset = dx + Cube.SIZE / 2;
                 int zOffset = dz + Cube.SIZE / 2;
                 BlockPos aboveTop = PopulatorUtils.getSurfaceForCube(world, pos, xOffset, zOffset, 0, PopulatorUtils.SurfaceType.BLOCKING_MOVEMENT);

--- a/src/main/java/cubicchunks/worldgen/generator/custom/structure/CubicRavineGenerator.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/structure/CubicRavineGenerator.java
@@ -330,7 +330,7 @@ public class CubicRavineGenerator extends CubicStructureGenerator {
                     //most of these blocks beyond the not-stretched height range are never carved out
                     //the result is that instead the ravine isn't very small at the bottom,
                     //but ends with actual floor instead
-                    double widthDecreaseFactor = this.widthDecreaseFactors[(localY + generatedCubeY * 16) & 0xFF];
+                    double widthDecreaseFactor = this.widthDecreaseFactors[(localY + generatedCubeY * Cube.SIZE) & 0xFF];
                     if ((distX * distX + distZ * distZ) * widthDecreaseFactor + distY * distY / STRETCH_Y_FACTOR >= 1.0D) {
                         continue;
                     }
@@ -352,7 +352,7 @@ public class CubicRavineGenerator extends CubicStructureGenerator {
         float[] values = new float[1024];
         float value = 1.0F;
 
-        for (int i = 0; i < 256; ++i) {
+        for (int i = 0; i < Cube.SIZE*Cube.SIZE; ++i) {
             //~33% probability that the value will change at that height
             if (i == 0 || rand.nextInt(3) == 0) {
                 //value = 1.xxx, lower = higher probability -> Wider parts are more common.

--- a/src/main/java/cubicchunks/worldgen/generator/custom/structure/feature/CubicFeatureGenerator.java
+++ b/src/main/java/cubicchunks/worldgen/generator/custom/structure/feature/CubicFeatureGenerator.java
@@ -28,6 +28,7 @@ import static cubicchunks.util.Coords.cubeToCenterBlock;
 import cubicchunks.util.CubePos;
 import cubicchunks.util.XYZMap;
 import cubicchunks.world.ICubicWorld;
+import cubicchunks.world.cube.Cube;
 import cubicchunks.worldgen.generator.ICubePrimer;
 import cubicchunks.worldgen.generator.custom.structure.CubicStructureGenerator;
 import mcp.MethodsReturnNonnullByDefault;
@@ -113,9 +114,9 @@ public abstract class CubicFeatureGenerator extends CubicStructureGenerator {
             // TODO: cubic chunks version of isValidForPostProcess and notifyPostProcess (mixin)
             if (structStart.isSizeableStructure() && structStart.isValidForPostProcess(cubePos.chunkPos())
                     && structStart.getBoundingBox().intersectsWith(
-                    new StructureBoundingBox(centerX, centerY, centerZ, centerX + 15, centerY + 15, centerZ + 15))) {
+                    new StructureBoundingBox(centerX, centerY, centerZ, centerX + Cube.SIZE - 1, centerY + Cube.SIZE - 1, centerZ + Cube.SIZE - 1))) {
                 structStart.generateStructure(world, rand,
-                        new StructureBoundingBox(centerX, centerY, centerZ, centerX + 15, centerY + 15, centerZ + 15));
+                        new StructureBoundingBox(centerX, centerY, centerZ, centerX + Cube.SIZE - 1, centerY + Cube.SIZE - 1, centerZ + Cube.SIZE - 1));
                 structStart.notifyPostProcessAt(cubePos.chunkPos());
                 generated = true;
                 this.setStructureStart(structStart.getChunkPosX(), cubicStructureStart.getChunkPosY(), structStart.getChunkPosZ(), structStart);

--- a/src/main/java/cubicchunks/worldgen/generator/flat/FlatTerrainProcessor.java
+++ b/src/main/java/cubicchunks/worldgen/generator/flat/FlatTerrainProcessor.java
@@ -79,9 +79,9 @@ public class FlatTerrainProcessor extends BasicCubeGenerator {
             int fromY = layer.fromY - floorY;
             int toY = layer.toY - floorY;
             IBlockState iBlockState = layer.blockState;
-            for (int y = fromY > 0 ? fromY : 0; y < (toY < 16 ? toY : 16); y++) {
-                for (int x = 0; x < 16; x++) {
-                    for (int z = 0; z < 16; z++) {
+            for (int y = fromY > 0 ? fromY : 0; y < (toY < Cube.SIZE ? toY : Cube.SIZE); y++) {
+                for (int x = 0; x < Cube.SIZE; x++) {
+                    for (int z = 0; z < Cube.SIZE; z++) {
                         primer.setBlockState(x, y, z, iBlockState);
                     }
                 }


### PR DESCRIPTION
I started cleaning up in preparation for using 32³ sized cubes, it is however a reasonable change by itself.

- Replaced most occurrences of the magic number 16 with Cube.SIZE in adequate places.
- Introduces constant Cube.SIZE_D=16.0 for decimal uses of the cubes' size.
- Replaced most occurrences of "& 15" and ">> 4" with blockToLocal and blockToCube where applicable. Some occurrences do not directly relate to cubes and where thus left unchanged.