### PR TITLE
Vanilla path navigator optmization

### DIFF
--- a/src/main/java/cubicchunks/asm/mixin/selectable/common/MixinPathNavigate.java
+++ b/src/main/java/cubicchunks/asm/mixin/selectable/common/MixinPathNavigate.java
@@ -1,0 +1,102 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package cubicchunks.asm.mixin.selectable.common;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.pathfinding.NodeProcessor;
+import net.minecraft.pathfinding.Path;
+import net.minecraft.pathfinding.PathNavigate;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.ChunkCache;
+import net.minecraft.world.World;
+
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@Mixin(PathNavigate.class)
+public abstract class MixinPathNavigate {
+
+    @Shadow protected EntityLiving entity;
+    @Shadow protected NodeProcessor nodeProcessor;
+    @Shadow protected Path currentPath;
+    @Shadow protected World world;
+
+    @Shadow
+    protected abstract Vec3d getEntityPosition();
+
+    @Redirect(method = "getPathToPos", at = @At(value = "NEW", target = "net/minecraft/world/ChunkCache"))
+    private ChunkCache newChunkCacheToPosRedirect(World worldIn, BlockPos posFromIn, BlockPos posToIn, int subIn, BlockPos target) {
+        int x1 = (int) entity.posX;
+        int y1 = (int) entity.posY;
+        int z1 = (int) entity.posZ;
+        int x2 = target.getX();
+        int y2 = target.getY();
+        int z2 = target.getZ();
+        return new ChunkCache(worldIn, new BlockPos(Math.min(x1, x2), Math.min(y1, y2), Math.min(z1, z2)),
+                new BlockPos(Math.max(x1, x2), Math.max(y1, y2), Math.max(z1, z2)), 4);
+    }
+
+    @Redirect(method = "getPathToEntityLiving", at = @At(value = "NEW", target = "net/minecraft/world/ChunkCache"))
+    private ChunkCache newChunkCacheToLivingRedirect(World worldIn, BlockPos posFromIn, BlockPos posToIn, int subIn, Entity target) {
+        int x1 = (int) entity.posX;
+        int y1 = (int) entity.posY;
+        int z1 = (int) entity.posZ;
+        int x2 = (int) target.posX;
+        int y2 = (int) target.posY;
+        int z2 = (int) target.posZ;
+        return new ChunkCache(worldIn, new BlockPos(Math.min(x1, x2), Math.min(y1, y2), Math.min(z1, z2)),
+                new BlockPos(Math.max(x1, x2), Math.max(y1, y2), Math.max(z1, z2)), 4);
+    }
+
+    @Inject(method = "pathFollow", at = @At("HEAD"))
+    private void pathFollowInitWalkNodeProcessor(CallbackInfo ci) {
+        Vec3d vec1 = this.getEntityPosition();
+        Vec3d vec2 = this.currentPath.getVectorFromIndex(this.entity, this.currentPath.getCurrentPathLength() - 1);
+        int x1 = (int) vec1.x;
+        int y1 = (int) vec1.y;
+        int z1 = (int) vec1.z;
+        int x2 = (int) vec2.x;
+        int y2 = (int) vec2.y;
+        int z2 = (int) vec2.z;
+        ChunkCache chunkCache = new ChunkCache(world, new BlockPos(Math.min(x1, x2), Math.min(y1, y2), Math.min(z1, z2)),
+                new BlockPos(Math.max(x1, x2), Math.max(y1, y2), Math.max(z1, z2)), 4);
+        this.nodeProcessor.initProcessor(chunkCache, entity);
+    }
+
+    @Inject(method = "pathFollow", at = @At("RETURN"))
+    private void pathFollowShutWalkNodeProcessor(CallbackInfo ci) {
+        this.nodeProcessor.postProcess();
+    }
+}

--- a/src/main/java/cubicchunks/asm/mixin/selectable/common/MixinWalkNodeProcessor.java
+++ b/src/main/java/cubicchunks/asm/mixin/selectable/common/MixinWalkNodeProcessor.java
@@ -1,0 +1,84 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package cubicchunks.asm.mixin.selectable.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import cubicchunks.world.ICubicWorld;
+import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.pathfinding.NodeProcessor;
+import net.minecraft.pathfinding.WalkNodeProcessor;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos.MutableBlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@Mixin(WalkNodeProcessor.class)
+public abstract class MixinWalkNodeProcessor extends NodeProcessor {
+
+    @Redirect(method = "getSafePoint", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;collidesWithAnyBlock(Lnet/minecraft/util/math/AxisAlignedBB;)Z"), require = 2)
+    private boolean collidesWithAnyBlockRedirect(World worldIn, AxisAlignedBB aabb) {
+        if (((ICubicWorld) worldIn).isCubicWorld()) {
+            List<AxisAlignedBB> aabbList = new ArrayList<AxisAlignedBB>();
+            double minX = aabb.minX;
+            double minY = aabb.minY;
+            double minZ = aabb.minZ;
+            double maxX = aabb.maxX;
+            double maxY = aabb.maxY;
+            double maxZ = aabb.maxZ;
+            int x1 = MathHelper.floor(minX) - 1;
+            int y1 = MathHelper.floor(minY) - 1;
+            int z1 = MathHelper.floor(minZ) - 1;
+            int x2 = MathHelper.ceil(maxX) + 1;
+            int y2 = MathHelper.ceil(maxY) + 1;
+            int z2 = MathHelper.ceil(maxZ) + 1;
+            for (MutableBlockPos pos : MutableBlockPos.mutablesBetween(x1, y1, z1, x2, y2, z2)) {
+                IBlockState bstate = blockaccess.getBlockState(pos);
+                bstate.addCollisionBoxToList(worldIn, pos, aabb, aabbList,
+                        entity, false);
+                if (!aabbList.isEmpty())
+                    return true;
+            }
+            return false;
+        }
+        return worldIn.collidesWithAnyBlock(aabb);
+    }
+
+    @ModifyVariable(method = "getPathNodeType", at = @At("HEAD"))
+    public IBlockAccess getPathNodeTypeFromOwnBlockAccess(IBlockAccess world) {
+        return this.blockaccess;
+    }
+}

--- a/src/main/resources/cubicchunks.mixins.selectable.json
+++ b/src/main/resources/cubicchunks.mixins.selectable.json
@@ -6,6 +6,8 @@
     "minVersion": "0.6.15-SNAPSHOT",
     "plugin": "cubicchunks.asm.CubicChunksMixinConfig",
     "mixins": [
+        "common.MixinPathNavigate",
+        "common.MixinWalkNodeProcessor",
         "common.MixinChunkCache",
         "common.MixinWorld_SlowCollisionCheck",
         "common.MixinWorld_CollisionCheck",


### PR DESCRIPTION
With mixin 150-160 ms per tick

![screenshot from 2017-09-30 12-13-35](https://user-images.githubusercontent.com/6910858/31044492-52678e92-a5e1-11e7-87df-6a72ff4142c3.png)

Without mixin 190-200 ms per tick

![screenshot from 2017-09-30 12-13-29](https://user-images.githubusercontent.com/6910858/31044493-526ef4de-a5e1-11e7-8381-e9933223c14c.png)

I'm not absolutely sure about tick time. But visual VM output shows that % of entity CPU time is decreased.

Test conditions: CubicChunks + Dungeon generator (with disabled entity tick hack). In a middle of dungeon.