### PR TITLE
Remove unnecessary changes from commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ dist
 lib
 out
 run
+run/**
+.mixin.out
+.mixin.out/**
 target
 *.com
 *.class


### PR DESCRIPTION
After `git add .` config file and `.mixin.out` folder content in root goes to commit. Annoying. This PR probably will fix that.