### PR TITLE
Workaround for invisible entities on death

### DIFF
--- a/src/main/java/cubicchunks/CommonEventHandler.java
+++ b/src/main/java/cubicchunks/CommonEventHandler.java
@@ -131,6 +131,8 @@ public class CommonEventHandler {
     public void onPlayerJoinWorld(EntityJoinWorldEvent evt) {
         if (evt.getEntity() instanceof EntityPlayerMP && ((ICubicWorld) evt.getWorld()).isCubicWorld()) {
             PacketDispatcher.sendTo(new PacketCubicWorldData((WorldServer) evt.getWorld()), (EntityPlayerMP) evt.getEntity());
+            // Workaround for issue when entities became invisible in cubes where player dies and which are not yet unloaded by garbage collector.
+            ((ICubicWorldServer)evt.getWorld()).getChunkGarbageCollector().chunkGc();
         }
     }
 

--- a/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorldServer.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorldServer.java
@@ -147,6 +147,11 @@ public abstract class MixinWorldServer extends MixinWorld implements ICubicWorld
         return (PlayerCubeMap) this.playerChunkMap;
     }
     
+    @Override
+    public ChunkGc getChunkGarbageCollector() {
+        return this.chunkGc;
+    }
+    
     @Inject(method = "scheduleUpdate", at = @At("HEAD"), cancellable = true, require = 1)
     public void scheduleUpdateInject(BlockPos pos, Block blockIn, int delay, CallbackInfo ci) {
         if (this.isCubicWorld()) {

--- a/src/main/java/cubicchunks/server/ChunkGc.java
+++ b/src/main/java/cubicchunks/server/ChunkGc.java
@@ -96,7 +96,7 @@ public class ChunkGc implements IConfigUpdateListener {
         }
     }
 
-    private void chunkGc() {
+    public void chunkGc() {
         Iterator<Cube> cubeIt = cubeCache.cubesIterator();
         while (cubeIt.hasNext()) {
             if (cubeCache.tryUnloadCube(cubeIt.next())) {

--- a/src/main/java/cubicchunks/world/ICubicWorldServer.java
+++ b/src/main/java/cubicchunks/world/ICubicWorldServer.java
@@ -26,6 +26,7 @@ package cubicchunks.world;
 import cubicchunks.IConfigUpdateListener;
 import cubicchunks.entity.CubicEntityTracker;
 import cubicchunks.lighting.FirstLightProcessor;
+import cubicchunks.server.ChunkGc;
 import cubicchunks.server.CubeProviderServer;
 import cubicchunks.server.PlayerCubeMap;
 import cubicchunks.util.IntRange;
@@ -64,4 +65,6 @@ public interface ICubicWorldServer extends ICubicWorld, IConfigUpdateListener {
     boolean canCreatureTypeSpawnHere(EnumCreatureType type, Biome.SpawnListEntry entry, BlockPos pos);
 
     CubicEntityTracker getCubicEntityTracker();
+    
+    ChunkGc getChunkGarbageCollector();
 }


### PR DESCRIPTION
I barely understand why, but this fix issue #295 
A player "ghost" in not yet unloaded cube?