### PR TITLE
Further collision optimization

### DIFF
--- a/src/main/java/cubicchunks/asm/CubicChunksMixinConfig.java
+++ b/src/main/java/cubicchunks/asm/CubicChunksMixinConfig.java
@@ -127,7 +127,9 @@ public class CubicChunksMixinConfig implements IMixinConfigPlugin {
                         + " You need to restart Minecraft to apply changes."),
         USE_FAST_COLLISION_CHECK(false, 
                 new String[] {"cubicchunks.asm.mixin.selectable.common.MixinWorld_SlowCollisionCheck"},
-                new String[] {"cubicchunks.asm.mixin.selectable.common.MixinWorld_CollisionCheck"},
+                new String[] {"cubicchunks.asm.mixin.selectable.common.MixinWorld_CollisionCheck",
+                        "cubicchunks.asm.mixin.selectable.common.MixinBlockStairs_FastCollision",
+                        "cubicchunks.asm.mixin.selectable.common.MixinBlock_FastCollision"},
                 "Enabling this option allow using fast collision check."
                         + " Fast collision check can reduce server lag."
                         + " You need to restart Minecraft to apply changes. DO NOT USE UNTIL FIXED!"),

--- a/src/main/java/cubicchunks/asm/mixin/selectable/common/MixinBlockStairs_FastCollision.java
+++ b/src/main/java/cubicchunks/asm/mixin/selectable/common/MixinBlockStairs_FastCollision.java
@@ -1,0 +1,64 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package cubicchunks.asm.mixin.selectable.common;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockStairs;
+import net.minecraft.block.material.MapColor;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+@Mixin(value = BlockStairs.class, priority = 1001)
+public abstract class MixinBlockStairs_FastCollision extends Block {
+    
+    public MixinBlockStairs_FastCollision(Material blockMaterialIn, MapColor blockMapColorIn) {
+        super(blockMaterialIn, blockMapColorIn);
+    }
+
+    /**
+     * @author Foghrye4
+     * @reason BlockStairs is really slow in this. 
+     * It is better to check if we need to do further calls.
+     **/
+    @Inject(method = "addCollisionBoxToList", at = @At("HEAD"), cancellable = true)
+    public void addCollisionBoxToList(IBlockState state, World worldIn, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes,
+            @Nullable Entity entityIn, boolean isActualState, CallbackInfo ci) {
+        AxisAlignedBB axisalignedbb = Block.FULL_BLOCK_AABB.offset(pos);
+        if (!entityBox.intersects(axisalignedbb))
+            ci.cancel();
+    }
+}

--- a/src/main/java/cubicchunks/asm/mixin/selectable/common/MixinBlock_FastCollision.java
+++ b/src/main/java/cubicchunks/asm/mixin/selectable/common/MixinBlock_FastCollision.java
@@ -1,0 +1,94 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package cubicchunks.asm.mixin.selectable.common;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import cubicchunks.block.state.BlockStairsFieldBasedBlockStateContainer;
+import cubicchunks.block.state.FullBlockBlockStateContainer;
+import cubicchunks.block.state.NonCollidingBlockStateContainer;
+import net.minecraft.block.*;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockStateContainer;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+
+@Mixin(value = Block.class, priority = 1001)
+public abstract class MixinBlock_FastCollision {
+
+    /**
+     * @author Foghrye4
+     * @reason Fasten state.addCollisionBoxToList() by replacing calls of block state to direct adding of FULL_BLOCK_AABB for full blocks.
+     **/
+    @Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;createBlockState()Lnet/minecraft/block/state/BlockStateContainer;"))
+    public BlockStateContainer alterBlockStateCollection(Block block) {
+        if (block instanceof BlockStairs) {
+            return new BlockStairsFieldBasedBlockStateContainer(block,
+                    new IProperty[] {BlockStairs.FACING, BlockStairs.HALF, BlockStairs.SHAPE});
+        }
+        BlockStateContainer oldBlockStateContainer = this.createBlockState();
+        Collection<IProperty<?>> properties = oldBlockStateContainer.getProperties();
+        boolean isFullBlock = true;
+        if (!(block instanceof BlockBreakable))
+            for (IBlockState state : oldBlockStateContainer.getValidStates()) {
+                if (!state.isFullCube())
+                    isFullBlock = false;
+            }
+        if (isFullBlock)
+            return new FullBlockBlockStateContainer(block, properties.toArray(new IProperty<?>[0]));
+        boolean isNonCollideableBlock = false;
+        if (block instanceof BlockBush ||
+                block instanceof BlockAir ||
+                block instanceof BlockButton ||
+                block instanceof BlockLiquid ||
+                block instanceof BlockFire) {
+            isNonCollideableBlock = true;
+            List<AxisAlignedBB> collidingBoxes = new ArrayList<AxisAlignedBB>();
+            try {
+                for (IBlockState state : oldBlockStateContainer.getValidStates())
+                    state.addCollisionBoxToList(null, BlockPos.ORIGIN, Block.FULL_BLOCK_AABB, collidingBoxes, null, false);
+                if (!collidingBoxes.isEmpty())
+                    isNonCollideableBlock = false;
+            }
+            // Catch all cases of modded extended classes accessing world here
+            catch (Exception e) {
+                isNonCollideableBlock = false;
+            }
+        }
+        if (isNonCollideableBlock)
+            return new NonCollidingBlockStateContainer(block, properties.toArray(new IProperty<?>[0]));
+        return oldBlockStateContainer;
+    }
+
+    @Shadow
+    abstract protected BlockStateContainer createBlockState();
+}

--- a/src/main/java/cubicchunks/asm/mixin/selectable/common/MixinWorld_CollisionCheck.java
+++ b/src/main/java/cubicchunks/asm/mixin/selectable/common/MixinWorld_CollisionCheck.java
@@ -33,6 +33,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import static cubicchunks.util.Coords.*;
+
 import cubicchunks.util.CubePos;
 import cubicchunks.world.ICubicWorld;
 import cubicchunks.world.cube.Cube;

--- a/src/main/java/cubicchunks/block/state/BlockStairsFieldBasedBlockStateContainer.java
+++ b/src/main/java/cubicchunks/block/state/BlockStairsFieldBasedBlockStateContainer.java
@@ -1,0 +1,49 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package cubicchunks.block.state;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableMap;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockStateContainer;
+import net.minecraft.block.state.IBlockState;
+
+public class BlockStairsFieldBasedBlockStateContainer extends BlockStateContainer {
+
+    private IBlockState[] propertyValueArray = new IBlockState[127];
+
+    public BlockStairsFieldBasedBlockStateContainer(Block blockIn, IProperty<?>[] properties) {
+        super(blockIn, properties);
+    }
+
+    protected StateImplementation createState(Block block, ImmutableMap<IProperty<?>, Comparable<?>> properties,
+            @Nullable ImmutableMap<net.minecraftforge.common.property.IUnlistedProperty<?>, java.util.Optional<?>> unlistedProperties) {
+        if (propertyValueArray == null)
+            propertyValueArray = new IBlockState[127];
+        return new BlockStairsFieldBasedStateImplementation(block, properties, propertyValueArray);
+    }
+}

--- a/src/main/java/cubicchunks/block/state/BlockStairsFieldBasedStateImplementation.java
+++ b/src/main/java/cubicchunks/block/state/BlockStairsFieldBasedStateImplementation.java
@@ -1,0 +1,83 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package cubicchunks.block.state;
+
+import com.google.common.collect.ImmutableMap;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockStairs;
+import net.minecraft.block.BlockStairs.EnumHalf;
+import net.minecraft.block.BlockStairs.EnumShape;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockStateContainer.StateImplementation;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.EnumFacing;
+
+public class BlockStairsFieldBasedStateImplementation extends StateImplementation {
+
+    private final IBlockState[] propertyValueArray;
+    private final EnumFacing facing; // 6 values
+    private final BlockStairs.EnumHalf half; // 2 values
+    private final BlockStairs.EnumShape shape; // 5 values
+
+    public BlockStairsFieldBasedStateImplementation(Block blockIn, ImmutableMap<IProperty<?>, Comparable<?>> propertiesIn, IBlockState[] propertyValueArrayIn) {
+        super(blockIn, propertiesIn);
+        facing = (EnumFacing) propertiesIn.get(BlockStairs.FACING);
+        half = (EnumHalf) propertiesIn.get(BlockStairs.HALF);
+        shape = (EnumShape) propertiesIn.get(BlockStairs.SHAPE);
+        propertyValueArray = propertyValueArrayIn;
+        propertyValueArray[propertyIndex(facing,half,shape)] = this;
+    }
+    
+    private static int propertyIndex(EnumFacing facingIn, BlockStairs.EnumHalf halfIn, BlockStairs.EnumShape shapeIn){
+        return facingIn.ordinal() | halfIn.ordinal() << 3 | shapeIn.ordinal() << 4;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T extends Comparable<T>> T getValue(IProperty<T> property) {
+        if (property == BlockStairs.FACING)
+            return (T) facing;
+        if (property == BlockStairs.HALF)
+            return (T) half;
+        if (property == BlockStairs.SHAPE)
+            return (T) shape;
+        throw new IllegalArgumentException("Cannot get property " + property + " as it does not exist in " + this.getBlock().getBlockState());
+    }
+    
+    @Override
+    public <T extends Comparable<T>, V extends T> IBlockState withProperty(IProperty<T> property, V value)
+    {
+        int index = 0;
+        if (property == BlockStairs.FACING)
+            index = propertyIndex((EnumFacing) value,half,shape);
+        else if (property == BlockStairs.HALF)
+            index = propertyIndex(facing,(EnumHalf) value,shape);
+        else if (property == BlockStairs.SHAPE)
+            index = propertyIndex(facing,half,(EnumShape) value);
+        else
+            throw new IllegalArgumentException("Cannot set property " + property + " as it does not exist in " + this.getBlock().getBlockState());
+        return propertyValueArray[index];
+    }
+}

--- a/src/main/java/cubicchunks/block/state/FullBlockBlockStateContainer.java
+++ b/src/main/java/cubicchunks/block/state/FullBlockBlockStateContainer.java
@@ -1,0 +1,45 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package cubicchunks.block.state;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableMap;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockStateContainer;
+import net.minecraft.block.state.IBlockState;
+
+public class FullBlockBlockStateContainer extends BlockStateContainer {
+
+    public FullBlockBlockStateContainer(Block blockIn, IProperty<?>[] properties) {
+        super(blockIn, properties);
+    }
+
+    protected StateImplementation createState(Block block, ImmutableMap<IProperty<?>, Comparable<?>> properties,
+            @Nullable ImmutableMap<net.minecraftforge.common.property.IUnlistedProperty<?>, java.util.Optional<?>> unlistedProperties) {
+        return new FullBlockStateImplementation(block, properties);
+    }
+}

--- a/src/main/java/cubicchunks/block/state/FullBlockStateImplementation.java
+++ b/src/main/java/cubicchunks/block/state/FullBlockStateImplementation.java
@@ -1,0 +1,58 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package cubicchunks.block.state;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableMap;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockStateContainer.StateImplementation;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class FullBlockStateImplementation extends StateImplementation {
+
+    public FullBlockStateImplementation(Block blockIn, ImmutableMap<IProperty<?>, Comparable<?>> propertiesIn) {
+        super(blockIn, propertiesIn);
+    }
+
+    @Override
+    public void addCollisionBoxToList(World worldIn, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes,
+            @Nullable Entity entityIn, boolean isActualState) {
+        int x1 = pos.getX();
+        int y1 = pos.getY();
+        int z1 = pos.getZ();
+        int x2 = x1 + 1;
+        int y2 = y1 + 1;
+        int z2 = z1 + 1;
+        if (entityBox.minX < x2 && entityBox.maxX > x1 && entityBox.minY < y2 && entityBox.maxY > y1 && entityBox.minZ < z2 && entityBox.maxZ > z1)
+            collidingBoxes.add(new AxisAlignedBB(x1, y1, z1, x2, y2, z2));
+    }
+}

--- a/src/main/java/cubicchunks/block/state/NonCollidingBlockStateContainer.java
+++ b/src/main/java/cubicchunks/block/state/NonCollidingBlockStateContainer.java
@@ -1,0 +1,45 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package cubicchunks.block.state;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableMap;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockStateContainer;
+import net.minecraft.block.state.IBlockState;
+
+public class NonCollidingBlockStateContainer extends BlockStateContainer {
+
+    public NonCollidingBlockStateContainer(Block blockIn, IProperty<?>[] properties) {
+        super(blockIn, properties);
+    }
+
+    protected StateImplementation createState(Block block, ImmutableMap<IProperty<?>, Comparable<?>> properties,
+            @Nullable ImmutableMap<net.minecraftforge.common.property.IUnlistedProperty<?>, java.util.Optional<?>> unlistedProperties) {
+        return new NonCollidingBlockStateImplementation(block, properties);
+    }
+}

--- a/src/main/java/cubicchunks/block/state/NonCollidingBlockStateImplementation.java
+++ b/src/main/java/cubicchunks/block/state/NonCollidingBlockStateImplementation.java
@@ -1,0 +1,50 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package cubicchunks.block.state;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableMap;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockStateContainer.StateImplementation;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class NonCollidingBlockStateImplementation extends StateImplementation {
+
+    public NonCollidingBlockStateImplementation(Block blockIn, ImmutableMap<IProperty<?>, Comparable<?>> propertiesIn) {
+        super(blockIn, propertiesIn);
+    }
+
+    @Override
+    public void addCollisionBoxToList(World worldIn, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes,
+            @Nullable Entity entityIn, boolean isActualState) {
+    }
+}

--- a/src/main/resources/cubicchunks.mixins.selectable.json
+++ b/src/main/resources/cubicchunks.mixins.selectable.json
@@ -11,6 +11,8 @@
         "common.MixinChunkCache",
         "common.MixinWorld_SlowCollisionCheck",
         "common.MixinWorld_CollisionCheck",
+        "common.MixinBlockStairs_FastCollision",
+        "common.MixinBlock_FastCollision",
         "common.MixinWorldServer_UpdateBlocks"
     ],
     "client": [


### PR DESCRIPTION
I'm still not happy with "fast" collision optimization. VisualVM showed that it use a lot of CPU time for calls BlockstateImplementation->Block->BlockstateImplementation->Block (excluding MalisisCore hooks).
This version is about 10% faster than previous by shorten calls for full blocks and non-collideable blocks using custom IBlockState implementation for such blocks.
I was able to reduce tick time from 95 ms to 85 ms in average and % of CPU time used by `handler$addBlocksCollisionBoundingBoxToList(...)` from 16% to 10%.
![screenshot from 2017-12-14 12-58-19](https://user-images.githubusercontent.com/6910858/33995153-1ed88e6c-e0ee-11e7-8643-2fab36fac199.png)
![screenshot from 2017-12-13 22-40-34](https://user-images.githubusercontent.com/6910858/33995205-4d2c4588-e0ee-11e7-8cc2-cd4ad2c36693.png)

