### PR TITLE
Clean unused interface function

### DIFF
--- a/src/main/java/cubicchunks/CommonEventHandler.java
+++ b/src/main/java/cubicchunks/CommonEventHandler.java
@@ -33,12 +33,9 @@ import cubicchunks.world.ICubicWorld;
 import cubicchunks.world.ICubicWorldServer;
 import cubicchunks.world.ICubicWorldSettings;
 import cubicchunks.world.WorldSavedCubicChunksData;
-import cubicchunks.world.provider.ICubicWorldProvider;
 import cubicchunks.world.type.ICubicWorldType;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.WorldServerMulti;
@@ -85,7 +82,7 @@ public class CommonEventHandler {
         }
         CubicChunks.LOGGER.info("Initializing world " + evt.getObject() + " with type " + evt.getObject().getWorldType());
 
-        IntRange generationRange = new IntRange(0, ((ICubicWorldProvider) world.getProvider()).getOriginalActualHeight());
+        IntRange generationRange = new IntRange(0, world.getProvider().getActualHeight());
         WorldType type = evt.getObject().getWorldType();
         if (type instanceof ICubicWorldType) {
             generationRange = ((ICubicWorldType) type).calculateGenerationHeightRange((WorldServer) world);

--- a/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorldProvider.java
+++ b/src/main/java/cubicchunks/asm/mixin/core/common/MixinWorldProvider.java
@@ -60,8 +60,6 @@ public abstract class MixinWorldProvider implements ICubicWorldProvider {
 
     @Shadow(remap = false) public abstract int getActualHeight();
 
-    private boolean getActualHeightForceOriginalFlag = false;
-
     /**
      * @reason return the real world height instead of hardcoded 256
      * @author Barteks2x
@@ -77,15 +75,6 @@ public abstract class MixinWorldProvider implements ICubicWorldProvider {
             return;
         }
         cir.setReturnValue(((ICubicWorld)world).getMaxGenerationHeight());
-    }
-
-    @Override public int getOriginalActualHeight() {
-        try {
-            getActualHeightForceOriginalFlag = true;
-            return getActualHeight();
-        } finally {
-            getActualHeightForceOriginalFlag = false;
-        }
     }
 
     @Nullable @Override public ICubeGenerator createCubeGenerator() {

--- a/src/main/java/cubicchunks/world/provider/ICubicWorldProvider.java
+++ b/src/main/java/cubicchunks/world/provider/ICubicWorldProvider.java
@@ -39,6 +39,4 @@ public interface ICubicWorldProvider {
      * @return a new Cube generator
      */
     @Nullable ICubeGenerator createCubeGenerator();
-
-    int getOriginalActualHeight();
 }

--- a/src/main/java/cubicchunks/world/type/VanillaCubicWorldType.java
+++ b/src/main/java/cubicchunks/world/type/VanillaCubicWorldType.java
@@ -26,11 +26,9 @@ package cubicchunks.world.type;
 import cubicchunks.CubicChunks;
 import cubicchunks.util.IntRange;
 import cubicchunks.world.ICubicWorld;
-import cubicchunks.world.provider.ICubicWorldProvider;
 import cubicchunks.worldgen.generator.ICubeGenerator;
 import cubicchunks.worldgen.generator.vanilla.VanillaCompatibilityGenerator;
 import mcp.MethodsReturnNonnullByDefault;
-import net.minecraft.world.WorldProvider;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.WorldType;
 
@@ -59,6 +57,6 @@ public class VanillaCubicWorldType extends WorldType implements ICubicWorldType 
     }
 
     @Override public IntRange calculateGenerationHeightRange(WorldServer world) {
-        return new IntRange(0, ((ICubicWorldProvider) world.provider).getOriginalActualHeight());
+        return new IntRange(0, world.provider.getActualHeight());
     }
 }


### PR DESCRIPTION
I guess that was a kind of hack to get actual height of a vanilla world, but currently it return regular `getActualHeight()` in all cases.