### PR TITLE
Distribute entities during initial worldgen spawn

### DIFF
--- a/src/api/java/io/github/opencubicchunks/cubicchunks/api/worldgen/populator/WorldGenEntitySpawner.java
+++ b/src/api/java/io/github/opencubicchunks/cubicchunks/api/worldgen/populator/WorldGenEntitySpawner.java
@@ -36,6 +36,8 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldEntitySpawner;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.biome.Biome;
+import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.fml.common.eventhandler.Event;
 
 import java.util.List;
 import java.util.Random;
@@ -65,6 +67,12 @@ public class WorldGenEntitySpawner {
 
             for (int i = 0; i < groupCount; ++i) {
                 for (int j = 0; j < 4; ++j) {
+                    randX += random.nextInt(5) - random.nextInt(5);
+                    randZ += random.nextInt(5) - random.nextInt(5);
+                    while (randX < blockX || randX >= blockX + sizeX || randZ < blockZ || randZ >= blockZ + sizeZ) {
+                        randX = initRandX + random.nextInt(5) - random.nextInt(5);
+                        randZ = initRandZ + random.nextInt(5) - random.nextInt(5);
+                    }
                     BlockPos pos = ((ICubicWorld)world).findTopBlock(new BlockPos(randX, blockY + sizeY + ICube.SIZE / 2, randZ),
                             blockY, blockY + sizeY - 1, ICubicWorld.SurfaceType.SOLID);
                     if (pos == null) {
@@ -82,17 +90,15 @@ public class WorldGenEntitySpawner {
                         }
 
                         spawnedEntity.setLocationAndAngles(randX + 0.5, pos.getY(), randZ + 0.5, random.nextFloat() * 360.0F, 0.0F);
+                        Event.Result forgeCanSpawn = ForgeEventFactory.canEntitySpawn(spawnedEntity, world, randX + 0.5f, (float) pos.getY(), randZ + 0.5f, null);
+                        if (forgeCanSpawn == Event.Result.DENY) {
+                            spawnedEntity.setDead();
+                            continue;
+                        }
                         world.spawnEntity(spawnedEntity);
                         data = spawnedEntity.onInitialSpawn(world.getDifficultyForLocation(new BlockPos(spawnedEntity)), data);
                         break;
                     }
-                    randX += random.nextInt(5) - random.nextInt(5);
-                    randZ += random.nextInt(5) - random.nextInt(5);
-                    while (randX < blockX || randX >= blockX + sizeX || randZ < blockZ || randZ >= blockZ + sizeZ) {
-                        randX = initRandX + random.nextInt(5) - random.nextInt(5);
-                        randZ = initRandZ + random.nextInt(5) - random.nextInt(5);
-                    }
-
                 }
             }
         }


### PR DESCRIPTION
This is slightly controversial, because:
1. Algorithm does not match a vanilla algorithm serving a same purpose.
2. It does not resolve underlaying problem of a random numbers being not enough random.
Yet it doing a job of more or less natural looking animal spreading during worldgen. I also added a missing event (which is exist in vanilla code).
![screenshot from 2018-09-30 18-12-44](https://user-images.githubusercontent.com/6910858/46259061-746dc400-c4dc-11e8-85c6-2cfa26f1af95.png)
