### PR TITLE
Fix BetterFps FastBeacon Compatibility

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/core/asm/CubicChunksMixinConfig.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/core/asm/CubicChunksMixinConfig.java
@@ -109,6 +109,27 @@ public class CubicChunksMixinConfig implements IMixinConfigPlugin {
                 "io.github.opencubicchunks.cubicchunks.core.asm.mixin.selectable.client.optifine.MixinExtendedBlockStorage",
                 optifineState != OptifineState.NOT_LOADED);
 
+        //BetterFps FastBeacon Handling
+        boolean enableBetterFpsBeaconFix = false;
+        try{
+            Class betterFpsConditions = Class.forName("guichaguri.betterfps.transformers.Conditions");
+            Method getFixSetting = betterFpsConditions.getMethod("shouldPatch", String.class);
+            boolean betterFpsFastBeaconActive = (boolean) getFixSetting.invoke(null, "fastBeacon");
+            if(betterFpsFastBeaconActive){
+                enableBetterFpsBeaconFix = true;
+                LOGGER.info("BetterFps FastBeacon active, will activate mixin for beacons with FastBeacon.");
+            }else{
+                LOGGER.info("BetterFps is installed, but FastBeacon is not active. Will not enable FastBeacon mixin.");
+            }
+        } catch (ClassNotFoundException e) {
+            LOGGER.info("BetterFps is NOT installed. Will not enable FastBeacon mixin.");
+        } catch (Exception e) {
+            LOGGER.info("Problem trying to detect BetterFps settings. Will not enable FastBeacon mixin.");
+        }
+        modDependencyConditions.put(
+                "io.github.opencubicchunks.cubicchunks.core.asm.mixin.selectable.common.MixinTileEntityBeaconBetterFps", 
+                enableBetterFpsBeaconFix);
+
         File folder = new File(".", "config");
         folder.mkdirs();
         File configFile = new File(folder, "cubicchunks_mixin_config.json");

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/core/asm/mixin/noncritical/common/MixinTileEntityBeacon.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/core/asm/mixin/noncritical/common/MixinTileEntityBeacon.java
@@ -21,7 +21,7 @@
  *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  *  THE SOFTWARE.
  */
-package io.github.opencubicchunks.cubicchunks.core.asm.mixin.fixes.common;
+package io.github.opencubicchunks.cubicchunks.core.asm.mixin.noncritical.common;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/core/asm/mixin/selectable/common/MixinTileEntityBeaconBetterFps.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/core/asm/mixin/selectable/common/MixinTileEntityBeaconBetterFps.java
@@ -1,0 +1,40 @@
+/*
+ *  This file is part of Cubic Chunks Mod, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package io.github.opencubicchunks.cubicchunks.core.asm.mixin.selectable.common;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import io.github.opencubicchunks.cubicchunks.api.world.ICubicWorld;
+import net.minecraft.tileentity.TileEntityBeacon;
+import net.minecraft.tileentity.TileEntityLockable;
+
+@Mixin(TileEntityBeacon.class)
+public abstract class MixinTileEntityBeaconBetterFps extends TileEntityLockable {
+    
+    @ModifyConstant(method = "updateLevels", constant = @Constant(expandZeroConditions = Constant.Condition.LESS_THAN_ZERO))
+    private int updateLevelsYValue(int orig) {
+        return ((ICubicWorld) world).getMinHeight();
+    }
+}

--- a/src/main/resources/cubicchunks.mixins.fixes.json
+++ b/src/main/resources/cubicchunks.mixins.fixes.json
@@ -19,7 +19,6 @@
         "common.MixinRandomPositionGenerator",
         "common.MixinPathNavigateGround",
         "common.MixinTeleporter",
-        "common.MixinTileEntityBeacon",
         "common.MixinTileEntityEndGateway",
         "common.MixinPacketBufferBlockPosWrite",
         "common.MixinNetHandlerPlayServer",

--- a/src/main/resources/cubicchunks.mixins.noncritical.json
+++ b/src/main/resources/cubicchunks.mixins.noncritical.json
@@ -11,7 +11,8 @@
         "common.command.MixinCommandBase",
         "common.command.MixinCommandFill",
         "common.command.MixinCommandsHeightLimits",
-        "common.MixinBlockPistonBase_HeightFix"
+        "common.MixinBlockPistonBase_HeightFix",
+        "common.MixinTileEntityBeacon"
     ],
     "client": [
         "client.MixinViewFrustum_VertViewDistance",

--- a/src/main/resources/cubicchunks.mixins.selectable.json
+++ b/src/main/resources/cubicchunks.mixins.selectable.json
@@ -11,7 +11,8 @@
         "common.MixinChunkCache",
         "common.MixinWorld_SlowCollisionCheck",
         "common.MixinWorld_CollisionCheck",
-        "common.MixinWorldServer_UpdateBlocks"
+        "common.MixinWorldServer_UpdateBlocks",
+        "common.MixinTileEntityBeaconBetterFps"
     ],
     "client": [
         "client.MixinRenderGlobalNoOptifine",


### PR DESCRIPTION
Ok, another attempt, hopefully without messing up the branch this time...

- Moves the Beacon y<0 fix to noncritical to avoid crashing when the mixin fails due to another mod modifying the method
- adds a fix for BetterFps beacon edit that is only applied when the BetterFps beacon fix is registered as active.