### PR TITLE
Made 1.15 build on MacOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ repositories{
 configurations.getByName("annotationProcessor").extendsFrom(configurations.compileClasspath)
 
 // for vulkan
-project.ext.lwjglVersion = "3.2.2"
+project.ext.lwjglVersion = "3.2.1"
 
 switch (OperatingSystem.current()) {
     case OperatingSystem.LINUX:
@@ -143,6 +143,9 @@ switch (OperatingSystem.current()) {
         break
     case OperatingSystem.WINDOWS:
         project.ext.lwjglNatives = System.getProperty("os.arch").contains("64") ? "natives-windows" : "natives-windows-x86"
+        break
+    case OperatingSystem.MAC_OS:
+        project.ext.lwjglNatives = "natives-macos"
         break
 }
 


### PR DESCRIPTION
(In addition to not having an entry for the natives for MacOS) It didn't previously because java on Mac allows a more recently loaded classpath to override another. This was problematic here because Minecraft 1.15.2 uses LWJGL 3.2.1 while we were using LWJGL 3.2.2, though that doesn't fully explain it. I suspect it had something to do with the natives overriding and not matching the version of Minecraft natives while minecraft was still using the 3.2.1 API.

TL;DR I decremented the incremental version number to match that of Minecraft 1.15.2 of LWJGL and it fixed it. :D