### PR TITLE
[1.16] Fix tall flower placement above y=255

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/block/MixinDoublePlantBlock.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/block/MixinDoublePlantBlock.java
@@ -1,0 +1,19 @@
+package io.github.opencubicchunks.cubicchunks.mixin.core.common.block;
+
+import io.github.opencubicchunks.cubicchunks.CubicChunks;
+import net.minecraft.block.DoublePlantBlock;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(DoublePlantBlock.class)
+public class MixinDoublePlantBlock {
+
+    /**
+     @author CursedFlames
+     @reason Fix tall flower placement above 255
+     **/
+    @ModifyConstant(method = "getStateForPlacement", constant = @Constant(intValue = 255))
+    private int getOutOfWorldMaxPos(int _255) { return CubicChunks.MAX_SUPPORTED_HEIGHT; }
+
+}

--- a/src/main/resources/cubicchunks.mixins.core.json
+++ b/src/main/resources/cubicchunks.mixins.core.json
@@ -12,6 +12,7 @@
     },
     "mixins": [
         "common.block.MixinDoorBlock",
+        "common.block.MixinDoublePlantBlock",
         "common.block.MixinFallingBlock",
         "common.chunk.MixinChunk",
         "common.chunk.MixinChunkCache_HeightLimits",


### PR DESCRIPTION
Bizarrely, this issue only occurs in 1.16, so no need for a 1.15 version. Fixes #566. Basically identical to #561 :woman_shrugging: 