### PR TITLE
Fixed teleporting beyond 20,000,000 vertical block limit

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/MixinWorld.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/MixinWorld.java
@@ -24,6 +24,11 @@ public abstract class MixinWorld implements ICubicWorld {
         cir.setReturnValue(y < CubicChunks.MIN_SUPPORTED_HEIGHT || y >= CubicChunks.MAX_SUPPORTED_HEIGHT);
     }
 
+    @Inject(at = @At("RETURN"), method = "isInvalidYPosition", cancellable = true)
+    private static void isInvalidYPosition(int y, CallbackInfoReturnable<Boolean> cir) {
+        cir.setReturnValue(y < CubicChunks.MIN_SUPPORTED_HEIGHT || y >= CubicChunks.MAX_SUPPORTED_HEIGHT);
+    }
+
     @Inject(method = "markChunkDirty", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/Chunk;markDirty()V"))
     private void onMarkChunkDirty(BlockPos blockPos, TileEntity tileEntity, CallbackInfo ci) {
         this.getCubeAt(blockPos).setDirty(true);


### PR DESCRIPTION
Fixes #552, but also exposes the bigger issue of players getting kicked beyond 30,000,000 more, since it is now possible to teleport to positions outside that range. Looking into that next.