### PR TITLE
reusable CubePrimer

### DIFF
--- a/CubicChunksAPI/src/main/java/io/github/opencubicchunks/cubicchunks/api/worldgen/CubePrimer.java
+++ b/CubicChunksAPI/src/main/java/io/github/opencubicchunks/cubicchunks/api/worldgen/CubePrimer.java
@@ -33,6 +33,7 @@ import net.minecraft.world.biome.Biome;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Arrays;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
@@ -142,6 +143,17 @@ public class CubePrimer {
             }
             extData[idx] = (byte) (value >>> 16);
         }
+    }
+
+    /**
+     * Resets this primer to a state as if it were newly constructed.
+     */
+    public void reset() {
+        Arrays.fill(this.data, '\0');
+
+        // simply reset extra data and biomes to null, these are unlikely to be set in most cases anyway
+        this.extData = null;
+        this.biomes3d = null;
     }
 
     /**

--- a/CubicChunksAPI/src/main/java/io/github/opencubicchunks/cubicchunks/api/worldgen/ICubeGenerator.java
+++ b/CubicChunksAPI/src/main/java/io/github/opencubicchunks/cubicchunks/api/worldgen/ICubeGenerator.java
@@ -63,9 +63,28 @@ public interface ICubeGenerator {
      * @param cubeY the cube's Y coordinate
      * @param cubeZ the cube's Z coordinate
      *
-     * @return An ICubePrimer with the generated blocks
+     * @return A CubePrimer with the generated blocks
+     * @deprecated generators are advised to implement {@link #generateCube(int, int, int, CubePrimer)}
      */
+    @Deprecated
     CubePrimer generateCube(int cubeX, int cubeY, int cubeZ);
+
+    /**
+     * Generate a new cube
+     *
+     * @param cubeX the cube's X coordinate
+     * @param cubeY the cube's Y coordinate
+     * @param cubeZ the cube's Z coordinate
+     * @param primer a CubePrimer which may be used for generating the new cube. Note that generators are allowed to return an
+     *               arbitrary CubePrimer, this parameter is simply a hint to help reduce allocations. However, if a different
+     *               primer is to be returned, the given primer's state must remain unmodified.
+     *
+     * @return A CubePrimer with the generated blocks
+     */
+    default CubePrimer generateCube(int cubeX, int cubeY, int cubeZ, CubePrimer primer) {
+        // proxy to legacy generateCube method to retain API backwards-compatibility
+        return this.generateCube(cubeX, cubeY, cubeZ);
+    }
 
     /**
      * Generate column-global information such as biome data


### PR DESCRIPTION
This allows `ICubeGenerator` implementations to re-use the same `CubePrimer` instance, thus eliminating 8KiB of allocations for every generated cube.