### PR TITLE
-Cubify all vanilla surface builders to prevent exceptions

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/surfacebuilder/MixinBadlandsSurfaceBuilder.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/surfacebuilder/MixinBadlandsSurfaceBuilder.java
@@ -1,0 +1,28 @@
+package io.github.opencubicchunks.cubicchunks.mixin.core.common.world.surfacebuilder;
+
+import java.util.Random;
+
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.levelgen.surfacebuilders.BadlandsSurfaceBuilder;
+import net.minecraft.world.level.levelgen.surfacebuilders.SurfaceBuilderBaseConfiguration;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(value = BadlandsSurfaceBuilder.class)
+public class MixinBadlandsSurfaceBuilder {
+
+    @ModifyConstant(method = "apply", constant = @Constant(expandZeroConditions = Constant.Condition.GREATER_THAN_OR_EQUAL_TO_ZERO))
+    private int doNotLoopOutsideCube(int arg0, Random random, ChunkAccess chunk, Biome biome, int i, int j, int height, double d, BlockState blockState, BlockState blockState2, int l,
+                                     long m, SurfaceBuilderBaseConfiguration surfaceBuilderBaseConfiguration) {
+        if (chunk.getMinBuildHeight() > arg0) {
+            return chunk.getMinBuildHeight();
+        } else if (chunk.getMaxBuildHeight() < arg0) {
+            return Integer.MAX_VALUE;
+        } else {
+            return arg0;
+        }
+    }
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/surfacebuilder/MixinDefaultSurfaceBuilder.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/surfacebuilder/MixinDefaultSurfaceBuilder.java
@@ -1,0 +1,31 @@
+package io.github.opencubicchunks.cubicchunks.mixin.core.common.world.surfacebuilder;
+
+import java.util.Random;
+
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.levelgen.surfacebuilders.DefaultSurfaceBuilder;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(DefaultSurfaceBuilder.class)
+public class MixinDefaultSurfaceBuilder {
+
+    @ModifyConstant(
+        method = "apply(Ljava/util/Random;Lnet/minecraft/world/level/chunk/ChunkAccess;Lnet/minecraft/world/level/biome/Biome;IIIDLnet/minecraft/world/level/block/state/BlockState;"
+            + "Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/BlockState;"
+            + "Lnet/minecraft/world/level/block/state/BlockState;I)V", constant = @Constant(intValue = 50))
+    private int doNotLoopOutsideCube(int arg0, Random random, ChunkAccess chunk, Biome biome, int x, int z, int height, double noise, BlockState defaultBlock, BlockState fluidBlock,
+                                    BlockState topBlock, BlockState underBlock, BlockState underwaterBlock, int seaLevel) {
+
+        if (chunk.getMinBuildHeight() > arg0) {
+            return chunk.getMinBuildHeight();
+        } else if (chunk.getMaxBuildHeight() < arg0) {
+            return Integer.MAX_VALUE;
+        } else {
+            return arg0;
+        }
+    }
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/surfacebuilder/MixinErodedBadlandsSurfaceBuilder.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/surfacebuilder/MixinErodedBadlandsSurfaceBuilder.java
@@ -1,0 +1,28 @@
+package io.github.opencubicchunks.cubicchunks.mixin.core.common.world.surfacebuilder;
+
+import java.util.Random;
+
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.levelgen.surfacebuilders.ErodedBadlandsSurfaceBuilder;
+import net.minecraft.world.level.levelgen.surfacebuilders.SurfaceBuilderBaseConfiguration;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(ErodedBadlandsSurfaceBuilder.class)
+public class MixinErodedBadlandsSurfaceBuilder {
+
+    @ModifyConstant(method = "apply", constant = @Constant(expandZeroConditions = Constant.Condition.GREATER_THAN_OR_EQUAL_TO_ZERO))
+    private int doNotLoopOutsideCube(int arg0, Random random, ChunkAccess chunk, Biome biome, int i, int j, int height, double d, BlockState blockState, BlockState blockState2, int l,
+                                     long m, SurfaceBuilderBaseConfiguration surfaceBuilderBaseConfiguration) {
+        if (chunk.getMinBuildHeight() > arg0) {
+            return chunk.getMinBuildHeight();
+        } else if (chunk.getMaxBuildHeight() < arg0) {
+            return Integer.MAX_VALUE;
+        } else {
+            return arg0;
+        }
+    }
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/surfacebuilder/MixinFrozenOceanSurfaceBuilder.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/surfacebuilder/MixinFrozenOceanSurfaceBuilder.java
@@ -1,0 +1,28 @@
+package io.github.opencubicchunks.cubicchunks.mixin.core.common.world.surfacebuilder;
+
+import java.util.Random;
+
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.levelgen.surfacebuilders.FrozenOceanSurfaceBuilder;
+import net.minecraft.world.level.levelgen.surfacebuilders.SurfaceBuilderBaseConfiguration;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(FrozenOceanSurfaceBuilder.class)
+public class MixinFrozenOceanSurfaceBuilder {
+
+    @ModifyConstant(method = "apply", constant = @Constant(expandZeroConditions = Constant.Condition.GREATER_THAN_OR_EQUAL_TO_ZERO))
+    private int doNotLoopOutsideCube(int arg0, Random random, ChunkAccess chunk, Biome biome, int i, int j, int height, double d, BlockState blockState, BlockState blockState2, int l,
+                                     long m, SurfaceBuilderBaseConfiguration surfaceBuilderBaseConfiguration) {
+        if (chunk.getMinBuildHeight() > arg0) {
+            return chunk.getMinBuildHeight();
+        } else if (chunk.getMaxBuildHeight() < arg0) {
+            return Integer.MAX_VALUE;
+        } else {
+            return arg0;
+        }
+    }
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/surfacebuilder/MixinSwampSurfaceBuilder.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/surfacebuilder/MixinSwampSurfaceBuilder.java
@@ -1,0 +1,28 @@
+package io.github.opencubicchunks.cubicchunks.mixin.core.common.world.surfacebuilder;
+
+import java.util.Random;
+
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.levelgen.surfacebuilders.SurfaceBuilderBaseConfiguration;
+import net.minecraft.world.level.levelgen.surfacebuilders.SwampSurfaceBuilder;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(SwampSurfaceBuilder.class)
+public class MixinSwampSurfaceBuilder {
+
+    @ModifyConstant(method = "apply", constant = @Constant(expandZeroConditions = Constant.Condition.GREATER_THAN_OR_EQUAL_TO_ZERO))
+    private int doNotLoopOutsideCube(int arg0, Random random, ChunkAccess chunk, Biome biome, int i, int j, int height, double d, BlockState blockState, BlockState blockState2, int l,
+                                     long m, SurfaceBuilderBaseConfiguration surfaceBuilderBaseConfiguration) {
+        if (chunk.getMinBuildHeight() > arg0) {
+            return chunk.getMinBuildHeight();
+        } else if (chunk.getMaxBuildHeight() < arg0) {
+            return Integer.MAX_VALUE;
+        } else {
+            return arg0;
+        }
+    }
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/surfacebuilder/WoodedBadlandsSurfaceBuilder.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/surfacebuilder/WoodedBadlandsSurfaceBuilder.java
@@ -1,0 +1,28 @@
+package io.github.opencubicchunks.cubicchunks.mixin.core.common.world.surfacebuilder;
+
+import java.util.Random;
+
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.levelgen.surfacebuilders.BadlandsSurfaceBuilder;
+import net.minecraft.world.level.levelgen.surfacebuilders.SurfaceBuilderBaseConfiguration;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(BadlandsSurfaceBuilder.class)
+public class WoodedBadlandsSurfaceBuilder {
+
+    @ModifyConstant(method = "apply", constant = @Constant(expandZeroConditions = Constant.Condition.GREATER_THAN_OR_EQUAL_TO_ZERO))
+    private int doNotLoopOutsideCube(int arg0, Random random, ChunkAccess chunk, Biome biome, int i, int j, int height, double d, BlockState blockState, BlockState blockState2, int l,
+                                     long m, SurfaceBuilderBaseConfiguration surfaceBuilderBaseConfiguration) {
+        if (chunk.getMinBuildHeight() > arg0) {
+            return chunk.getMinBuildHeight();
+        } else if (chunk.getMaxBuildHeight() < arg0) {
+            return Integer.MAX_VALUE;
+        } else {
+            return arg0;
+        }
+    }
+}

--- a/src/main/resources/cubicchunks.mixins.core.json
+++ b/src/main/resources/cubicchunks.mixins.core.json
@@ -73,7 +73,13 @@
         "common.world.structure.MixinStructureFeatureManager",
         "common.world.structure.MixinStructurePiece",
         "common.world.structure.MixinStructureStart",
-        "common.world.structure.pieces.MixinOceanRuinPieces"
+        "common.world.structure.pieces.MixinOceanRuinPieces",
+        "common.world.surfacebuilder.MixinBadlandsSurfaceBuilder",
+        "common.world.surfacebuilder.MixinDefaultSurfaceBuilder",
+        "common.world.surfacebuilder.MixinErodedBadlandsSurfaceBuilder",
+        "common.world.surfacebuilder.MixinFrozenOceanSurfaceBuilder",
+        "common.world.surfacebuilder.MixinSwampSurfaceBuilder",
+        "common.world.surfacebuilder.WoodedBadlandsSurfaceBuilder"
     ],
     "client": [
         "client.chunk.MixinRenderChunkRegion",


### PR DESCRIPTION
-Protects all usages of Vanilla Surface Builders for Cubic Chunks to prevent exceptions from being thrown in a cubic context