### PR TITLE
[1.17] Rewrite CubeBiomeContainer to be comprised of several Vanilla Biome Containers

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/IBigCube.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/IBigCube.java
@@ -6,7 +6,6 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-import io.github.opencubicchunks.cubicchunks.chunk.biome.CubeBiomeContainer;
 import io.github.opencubicchunks.cubicchunks.chunk.heightmap.SurfaceTrackerSection;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
 import io.github.opencubicchunks.cubicchunks.meta.EarlyConfig;
@@ -16,6 +15,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ChunkStatus;
 import net.minecraft.world.level.chunk.FeatureAccess;
 import net.minecraft.world.level.chunk.LevelChunkSection;
@@ -24,7 +24,7 @@ import net.minecraft.world.level.levelgen.feature.StructureFeature;
 import net.minecraft.world.level.levelgen.structure.StructureStart;
 import org.apache.logging.log4j.LogManager;
 
-public interface IBigCube extends BlockGetter, FeatureAccess {
+public interface IBigCube extends BlockGetter, ChunkAccess, FeatureAccess {
 
     int SECTION_DIAMETER = 16;
     int DIAMETER_IN_SECTIONS = EarlyConfig.getDiameterInSections();
@@ -86,8 +86,6 @@ public interface IBigCube extends BlockGetter, FeatureAccess {
 
     void setCubeInhabitedTime(long newCubeInhabitedTime);
     long getCubeInhabitedTime();
-
-    @Nullable CubeBiomeContainer getCubeBiomes();
 
     int getCubeLocalHeight(Heightmap.Types heightmapType, int x, int z);
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/IClientCubeProvider.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/IClientCubeProvider.java
@@ -2,10 +2,10 @@ package io.github.opencubicchunks.cubicchunks.chunk;
 
 import javax.annotation.Nullable;
 
-import io.github.opencubicchunks.cubicchunks.chunk.biome.CubeBiomeContainer;
 import io.github.opencubicchunks.cubicchunks.chunk.cube.BigCube;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.level.chunk.ChunkBiomeContainer;
 
 public interface IClientCubeProvider extends ICubeProvider {
 
@@ -15,6 +15,6 @@ public interface IClientCubeProvider extends ICubeProvider {
 
     void updateCubeViewRadius(int hDistance, int vDistance);
 
-    BigCube replaceWithPacketData(int cubeX, int cubeY, int cubeZ, @Nullable CubeBiomeContainer biomes, FriendlyByteBuf readBuffer, CompoundTag nbtTagIn,
+    BigCube replaceWithPacketData(int cubeX, int cubeY, int cubeZ, @Nullable ChunkBiomeContainer biomes, FriendlyByteBuf readBuffer, CompoundTag nbtTagIn,
                                   boolean cubeExists);
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/biome/ColumnBiomeContainer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/biome/ColumnBiomeContainer.java
@@ -44,7 +44,7 @@ public class ColumnBiomeContainer extends ChunkBiomeContainer {
             return DUMMY_BIOME;
         }
 
-        CubeBiomeContainer cubeBiomes = icube.getCubeBiomes();
+        ChunkBiomeContainer cubeBiomes = icube.getBiomes();
         if (cubeBiomes != null) {
             return cubeBiomes.getNoiseBiome(biomeX, biomeY, biomeZ);
         }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/biome/CubeBiomeContainer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/biome/CubeBiomeContainer.java
@@ -1,138 +1,137 @@
 package io.github.opencubicchunks.cubicchunks.chunk.biome;
 
-import javax.annotation.Nullable;
-
-import io.github.opencubicchunks.cubicchunks.CubicChunks;
 import io.github.opencubicchunks.cubicchunks.chunk.IBigCube;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
+import io.github.opencubicchunks.cubicchunks.mixin.access.common.BiomeContainerAccess;
+import io.github.opencubicchunks.cubicchunks.server.CubicLevelHeightAccessor;
+import io.github.opencubicchunks.cubicchunks.utils.Coords;
 import net.minecraft.core.IdMap;
+import net.minecraft.core.QuartPos;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.LevelHeightAccessor;
 import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.BiomeManager;
 import net.minecraft.world.level.biome.BiomeSource;
+import net.minecraft.world.level.chunk.ChunkBiomeContainer;
+import org.jetbrains.annotations.Nullable;
 
-public class CubeBiomeContainer implements BiomeManager.NoiseBiomeSource {
+public class CubeBiomeContainer extends ChunkBiomeContainer {
+    private final ChunkBiomeContainer[] containers;
 
-    private static final int SIZE_BITS = (int) Math.round(Math.log(IBigCube.DIAMETER_IN_BLOCKS) / Math.log(2.0D)) - 2;
-    public static final int CUBE_BIOMES_SIZE = 1 << SIZE_BITS + SIZE_BITS + SIZE_BITS;
-
-    private static final int CUBE_HORIZONTAL_MASK = (1 << SIZE_BITS) - 1;
-
-    private final IdMap<Biome> biomeRegistry;
-    private final Biome[] biomes;
-
-    @Environment(EnvType.CLIENT)
-    public CubeBiomeContainer(IdMap<Biome> idMap, int[] is) {
-        this.biomeRegistry = idMap;
-        if (is.length == 1) {
-            this.biomes = new Biome[1];
-        } else {
-            this.biomes = new Biome[CUBE_BIOMES_SIZE];
+    public CubeBiomeContainer(IdMap<Biome> idMap, LevelHeightAccessor heightAccessor) {
+        super(idMap, heightAccessor, (Biome[]) null);
+        if (!((CubicLevelHeightAccessor) heightAccessor).isCubic()) {
+            throw new UnsupportedOperationException("Calling a cube class in a non cubic world.");
         }
 
+        this.containers = new ChunkBiomeContainer[IBigCube.DIAMETER_IN_SECTIONS * IBigCube.DIAMETER_IN_SECTIONS];
+    }
 
-        for (int i = 0; i < this.biomes.length; ++i) {
-            int j = is[i];
-            Biome biome = idMap.byId(j);
-            if (biome == null) {
-                CubicChunks.LOGGER.warn("Received invalid biome id: {}", j);
-                this.biomes[i] = idMap.byId(0);
-            } else {
-                this.biomes[i] = biome;
+    public CubeBiomeContainer(IdMap<Biome> idMap, LevelHeightAccessor heightAccessor, int[] incomingBiomes) {
+        this(idMap, heightAccessor);
+        int biomeArraySize = (1 << BiomeContainerAccess.getWidthBits() + BiomeContainerAccess.getWidthBits()) * ceilDiv(heightAccessor.getHeight(), 4);
+        int[][] perBiomeContainerBiomeArray = new int[containers.length][];
+
+        for (int columnX = 0; columnX < IBigCube.DIAMETER_IN_SECTIONS; columnX++) {
+            for (int columnZ = 0; columnZ < IBigCube.DIAMETER_IN_SECTIONS; columnZ++) {
+                int containerIDX = columnZ * IBigCube.DIAMETER_IN_SECTIONS + columnX;
+                int[] biomeArray = new int[biomeArraySize];
+
+                int offset = (incomingBiomes.length / containers.length) * containerIDX;
+                int iterateRange = (incomingBiomes.length / containers.length) * (containerIDX + 1);
+
+                for (int i = offset; i < iterateRange; i++) {
+                    int incomingBiome = incomingBiomes[i];
+                    biomeArray[i - offset] = incomingBiome;
+                }
+
+                perBiomeContainerBiomeArray[containerIDX] = biomeArray;
+
+                ChunkBiomeContainer biomeContainer = new ChunkBiomeContainer(idMap, heightAccessor, perBiomeContainerBiomeArray[containerIDX]);
+
+                containers[containerIDX] = biomeContainer;
             }
         }
     }
 
-    public CubeBiomeContainer(IdMap<Biome> idMap, CubePos cubePos, BiomeSource biomeProviderIn) {
-        this.biomeRegistry = idMap;
-        Biome[] tempBiomes = new Biome[CUBE_BIOMES_SIZE];
 
-        int x = cubePos.minCubeX() >> 2;
-        int y = cubePos.minCubeY() >> 2;
-        int z = cubePos.minCubeZ() >> 2;
-
-        boolean allBiomesIdentical = true;
-        Biome firstBiome = biomeProviderIn.getNoiseBiome(x, y, z);
-        for (int k = 0; k < tempBiomes.length; ++k) {
-            int dx = k & CUBE_HORIZONTAL_MASK;
-            int dy = k >> SIZE_BITS + SIZE_BITS & CUBE_HORIZONTAL_MASK;
-            int dz = k >> SIZE_BITS & CUBE_HORIZONTAL_MASK;
-            Biome biome = biomeProviderIn.getNoiseBiome(x + dx, y + dy, z + dz);
-            if (biome != firstBiome) {
-                allBiomesIdentical = false;
-            }
-            tempBiomes[k] = biome;
-        }
-
-        if (allBiomesIdentical) {
-            this.biomes = new Biome[] { firstBiome };
-        } else {
-            this.biomes = tempBiomes;
-        }
+    public CubeBiomeContainer(IdMap<Biome> idMap, LevelHeightAccessor levelHeightAccessor, CubePos chunkPos, BiomeSource biomeSource) {
+        this(idMap, levelHeightAccessor, chunkPos, biomeSource, null);
     }
 
-    public CubeBiomeContainer(IdMap<Biome> idMap, CubePos cubePos, BiomeSource biomeProviderIn, @Nullable int[] biomeIds) {
-        this.biomeRegistry = idMap;
-        Biome[] tempBiomes = new Biome[CUBE_BIOMES_SIZE];
+    public CubeBiomeContainer(IdMap<Biome> idMap, LevelHeightAccessor heightAccessor, CubePos cubePos, BiomeSource biomeSource, @Nullable int[] incomingBiomes) {
+        this(idMap, heightAccessor);
+        int biomeArraySize = (1 << BiomeContainerAccess.getWidthBits() + BiomeContainerAccess.getWidthBits()) * ceilDiv(heightAccessor.getHeight(), 4);
 
-        int x = cubePos.minCubeX() >> 2;
-        int y = cubePos.minCubeY() >> 2;
-        int z = cubePos.minCubeZ() >> 2;
+        int[][] perBiomeContainerBiomeArray = new int[containers.length][];
 
-        boolean allBiomesIdentical = true;
-        Biome firstBiome = biomeProviderIn.getNoiseBiome(x, y, z);
-        if (biomeIds != null) {
-            for (int k = 0; k < biomeIds.length; ++k) {
-                tempBiomes[k] = idMap.byId(biomeIds[k]);
-                if (tempBiomes[k] == null) {
-                    int dx = k & CUBE_HORIZONTAL_MASK;
-                    int dy = k >> SIZE_BITS + SIZE_BITS & CUBE_HORIZONTAL_MASK;
-                    int dz = k >> SIZE_BITS & CUBE_HORIZONTAL_MASK;
-                    Biome biome = biomeProviderIn.getNoiseBiome(x + dx, y + dy, z + dz);
-                    if (biome != firstBiome) {
-                        allBiomesIdentical = false;
+        if (incomingBiomes != null) {
+            for (int columnX = 0; columnX < IBigCube.DIAMETER_IN_SECTIONS; columnX++) {
+                for (int columnZ = 0; columnZ < IBigCube.DIAMETER_IN_SECTIONS; columnZ++) {
+                    int containerIDX = columnZ * IBigCube.DIAMETER_IN_SECTIONS + columnX;
+                    int[] biomeArray = new int[biomeArraySize];
+
+                    int offset = (incomingBiomes.length / containers.length) * containerIDX;
+                    int iterateRange = (incomingBiomes.length / containers.length) * (containerIDX + 1);
+
+                    for (int i = offset; i < iterateRange; i++) {
+                        int incomingBiome = incomingBiomes[i];
+                        biomeArray[i] = incomingBiome;
                     }
-                    tempBiomes[k] = biome;
+
+                    perBiomeContainerBiomeArray[containerIDX] = biomeArray;
+
+                    ChunkPos pos = cubePos.asChunkPos(columnX, columnZ);
+
+                    ChunkBiomeContainer biomeContainer = new ChunkBiomeContainer(idMap, heightAccessor, pos, biomeSource, perBiomeContainerBiomeArray[containerIDX]);
+
+                    containers[containerIDX] = biomeContainer;
                 }
             }
         } else {
-            for (int k1 = 0; k1 < tempBiomes.length; ++k1) {
-                int dx = k1 & CUBE_HORIZONTAL_MASK;
-                int dy = k1 >> SIZE_BITS + SIZE_BITS & CUBE_HORIZONTAL_MASK;
-                int dz = k1 >> SIZE_BITS & CUBE_HORIZONTAL_MASK;
-                Biome biome = biomeProviderIn.getNoiseBiome(x + dx, y + dy, z + dz);
-                if (biome != firstBiome) {
-                    allBiomesIdentical = false;
+            for (int columnX = 0; columnX < IBigCube.DIAMETER_IN_SECTIONS; columnX++) {
+                for (int columnZ = 0; columnZ < IBigCube.DIAMETER_IN_SECTIONS; columnZ++) {
+                    int containerIDX = columnZ * IBigCube.DIAMETER_IN_SECTIONS + columnX;
+                    ChunkPos pos = cubePos.asChunkPos(columnX, columnZ);
+                    containers[containerIDX] = new ChunkBiomeContainer(idMap, heightAccessor, pos, biomeSource, incomingBiomes);
                 }
-                tempBiomes[k1] = biome;
             }
         }
-
-        if (allBiomesIdentical) {
-            this.biomes = new Biome[] { firstBiome };
-        } else {
-            this.biomes = tempBiomes;
-        }
     }
 
-    public int[] writeBiomes() {
-        int[] is = new int[this.biomes.length];
-
-        for (int i = 0; i < this.biomes.length; ++i) {
-            is[i] = this.biomeRegistry.getId(this.biomes[i]);
-        }
-        return is;
+    private static int ceilDiv(int i, int j) {
+        return (i + j - 1) / j;
     }
 
-    public Biome getNoiseBiome(int x, int y, int z) {
-        if (biomes.length == 1) {
-            return biomes[0];
-        }
+    public void setContainerForColumn(int columnX, int columnZ, ChunkBiomeContainer container) {
+        containers[columnZ * IBigCube.DIAMETER_IN_SECTIONS + columnX] = container;
+    }
 
-        int localX = x & CUBE_HORIZONTAL_MASK;
-        int localY = y & CUBE_HORIZONTAL_MASK;
-        int localZ = z & CUBE_HORIZONTAL_MASK;
-        return biomes[localY << SIZE_BITS + SIZE_BITS | localZ << SIZE_BITS | localX];
+    @Override public int[] writeBiomes() {
+        int totalLength = 0;
+        Biome[][] allBiomes = new Biome[containers.length][];
+
+        for (int i = 0, containersLength = containers.length; i < containersLength; i++) {
+            ChunkBiomeContainer container = containers[i];
+            allBiomes[i] = ((BiomeContainerAccess) container).getBiomes();
+            totalLength += allBiomes[i].length;
+        }
+        int[] biomeIDs = new int[totalLength];
+
+        int i = 0;
+        for (Biome[] biome : allBiomes) {
+            for (Biome biome1 : biome) {
+                biomeIDs[i] = ((BiomeContainerAccess) this).getBiomeRegistry().getId(biome1);
+                i++;
+            }
+        }
+        return biomeIDs;
+    }
+
+    @Override public Biome getNoiseBiome(int biomeX, int biomeY, int biomeZ) {
+        int chunkX = Coords.cubeLocalSection(QuartPos.toSection(biomeX));
+        int chunkZ = Coords.cubeLocalSection(QuartPos.toSection(biomeZ));
+
+        ChunkBiomeContainer container = containers[chunkZ * IBigCube.DIAMETER_IN_SECTIONS + chunkX];
+        return container.getNoiseBiome(biomeX, biomeY, biomeZ);
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/cube/CubePrimerWrapper.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/cube/CubePrimerWrapper.java
@@ -6,7 +6,6 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-import io.github.opencubicchunks.cubicchunks.chunk.biome.CubeBiomeContainer;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import net.minecraft.Util;
@@ -174,12 +173,8 @@ public class CubePrimerWrapper extends CubePrimer {
         return this.cube.isEmptyCube();
     }
 
-    @Deprecated @Override public ChunkBiomeContainer getBiomes() {
+    @Override public ChunkBiomeContainer getBiomes() {
         return this.cube.getBiomes();
-    }
-
-    @Override public CubeBiomeContainer getCubeBiomes() {
-        return this.cube.getCubeBiomes();
     }
 
     @Override public void setHeightmap(Heightmap.Types type, long[] data) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/access/common/BiomeContainerAccess.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/access/common/BiomeContainerAccess.java
@@ -11,4 +11,8 @@ public interface BiomeContainerAccess {
     @Accessor Biome[] getBiomes();
 
     @Accessor IdMap<Biome> getBiomeRegistry();
+
+    @Accessor("WIDTH_BITS") static int getWidthBits() {
+        throw new Error("Mixin did not apply");
+    }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/world/MixinClientChunkProvider.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/world/MixinClientChunkProvider.java
@@ -5,7 +5,6 @@ import javax.annotation.Nullable;
 import io.github.opencubicchunks.cubicchunks.CubicChunks;
 import io.github.opencubicchunks.cubicchunks.chunk.ClientChunkProviderCubeArray;
 import io.github.opencubicchunks.cubicchunks.chunk.IClientCubeProvider;
-import io.github.opencubicchunks.cubicchunks.chunk.biome.CubeBiomeContainer;
 import io.github.opencubicchunks.cubicchunks.chunk.cube.BigCube;
 import io.github.opencubicchunks.cubicchunks.chunk.cube.EmptyCube;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
@@ -18,6 +17,7 @@ import net.minecraft.client.multiplayer.ClientChunkCache;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.level.chunk.ChunkBiomeContainer;
 import net.minecraft.world.level.chunk.ChunkStatus;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.lighting.LevelLightEngine;
@@ -98,7 +98,7 @@ public abstract class MixinClientChunkProvider implements IClientCubeProvider {
 
     @Override
     public BigCube replaceWithPacketData(int cubeX, int cubeY, int cubeZ,
-                                         @Nullable CubeBiomeContainer biomes, FriendlyByteBuf readBuffer, CompoundTag nbtTagIn, boolean cubeExists) {
+                                         @Nullable ChunkBiomeContainer biomes, FriendlyByteBuf readBuffer, CompoundTag nbtTagIn, boolean cubeExists) {
 
         if (!this.cubeArray.inView(cubeX, cubeY, cubeZ)) {
             LOGGER.warn("Ignoring cube since it's not in the view range: {}, {}, {}", cubeX, cubeY, cubeZ);

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkGenerator.java
@@ -7,8 +7,6 @@ import java.util.function.Supplier;
 
 import io.github.opencubicchunks.cubicchunks.chunk.IBigCube;
 import io.github.opencubicchunks.cubicchunks.chunk.ICubeGenerator;
-import io.github.opencubicchunks.cubicchunks.chunk.biome.CubeBiomeContainer;
-import io.github.opencubicchunks.cubicchunks.chunk.cube.CubePrimer;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
 import io.github.opencubicchunks.cubicchunks.mixin.access.common.OverworldBiomeSourceAccess;
 import io.github.opencubicchunks.cubicchunks.server.CubicLevelHeightAccessor;
@@ -212,20 +210,6 @@ public abstract class MixinChunkGenerator implements ICubeGenerator {
                 .getNearestGeneratedFeature(serverLevel, serverLevel.structureFeatureManager(), blockPos, radius, skipExistingChunks, serverLevel.getSeed(), structureFeatureConfiguration));
         }
     }
-
-    @Inject(method = "createBiomes", at = @At("HEAD"), cancellable = true)
-    public void generateBiomes(Registry<Biome> registry, ChunkAccess chunkIn, CallbackInfo ci) {
-        if (!((CubicLevelHeightAccessor) chunkIn).isCubic()) {
-            return;
-        }
-
-        /* This can only be a  CubePrimer at this point due to the inject in MixinChunkStatus#cubicChunksBiome  */
-        IBigCube iCube = (IBigCube) chunkIn;
-        CubePos cubePos = ((IBigCube) chunkIn).getCubePos();
-        ((CubePrimer) iCube).setCubeBiomes(new CubeBiomeContainer(registry, cubePos, this.runtimeBiomeSource));
-        ci.cancel();
-    }
-
 
     @Override
     public void decorate(CubeWorldGenRegion region, StructureFeatureManager structureManager) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkStatus.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkStatus.java
@@ -157,20 +157,25 @@ public class MixinChunkStatus {
     private static void cubicChunksBiome(ServerLevel world, ChunkGenerator chunkGenerator, List<ChunkAccess> neighbors, ChunkAccess chunkAccess, CallbackInfo ci) {
         if (((CubicLevelHeightAccessor) world).generates2DChunks()) {
             if (chunkAccess instanceof IBigCube) {
-//                /* This can only be a  CubePrimer at this point due to the inject in MixinChunkStatus#cubicChunksBiome  */
-//                IBigCube iCube = (IBigCube) chunkAccess;
-//                CubePos cubePos = ((IBigCube) chunkAccess).getCubePos();
-//                ((CubePrimer) iCube).setCubeBiomes(new CubeBiomeContainer(world.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY), cubePos, this.runtimeBiomeSource));
                 return;
             }
             return;
         }
-        if (chunkAccess instanceof IBigCube) {
-            chunkGenerator.createBiomes(world.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY), chunkAccess);
+
+        if (chunkAccess instanceof CubePrimer) {
+            ci.cancel();
+            CubePrimer cube = ((CubePrimer) chunkAccess);
+            cube.setHeightToCubeBounds(true);
+            for (int columnX = 0; columnX < IBigCube.DIAMETER_IN_SECTIONS; columnX++) {
+                for (int columnZ = 0; columnZ < IBigCube.DIAMETER_IN_SECTIONS; columnZ++) {
+                    cube.moveColumns(columnX, columnZ);
+                    chunkGenerator.createBiomes(world.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY), chunkAccess);
+                }
+            }
+            cube.setHeightToCubeBounds(false);
             return;
         }
         ci.cancel();
-        //noinspection ConstantConditions
         ColumnBiomeContainer biomeContainer = new ColumnBiomeContainer(world.registryAccess().registryOrThrow(BIOME_REGISTRY), world, world);
         ((ProtoChunk) chunkAccess).setBiomes(biomeContainer);
     }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/MixinNaturalSpawner.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/MixinNaturalSpawner.java
@@ -20,7 +20,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.NaturalSpawner;
 import net.minecraft.world.level.PotentialCalculator;
-import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.levelgen.Heightmap;
@@ -113,16 +112,6 @@ public abstract class MixinNaturalSpawner {
         }
 
         cir.setReturnValue(CubicNaturalSpawner.isRightDistanceToPlayerAndSpawnPoint(world, chunk, pos, squaredDistance));
-    }
-
-
-    @Inject(method = "getRoughBiome", at = @At("HEAD"), cancellable = true)
-    private static void getRoughCubicBiome(BlockPos pos, ChunkAccess chunk, CallbackInfoReturnable<Biome> cir) {
-        if (!((CubicLevelHeightAccessor) chunk).isCubic() || !(chunk instanceof IBigCube)) {
-            return;
-        }
-
-        cir.setReturnValue(CubicNaturalSpawner.getRoughBiomeForCube(pos, chunk));
     }
 
     private static ThreadLocal<BlockPos> capturedPos = new ThreadLocal<>();

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/network/PacketCubes.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/network/PacketCubes.java
@@ -13,7 +13,9 @@ import io.github.opencubicchunks.cubicchunks.chunk.IClientCubeProvider;
 import io.github.opencubicchunks.cubicchunks.chunk.biome.CubeBiomeContainer;
 import io.github.opencubicchunks.cubicchunks.chunk.cube.BigCube;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
+import io.github.opencubicchunks.cubicchunks.server.CubicLevelHeightAccessor;
 import io.github.opencubicchunks.cubicchunks.utils.MathUtil;
+import io.github.opencubicchunks.cubicchunks.world.storage.CubeSerializer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import net.minecraft.client.Minecraft;
@@ -24,6 +26,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.ChunkBiomeContainer;
 
 public class PacketCubes {
     // vanilla has max chunk size of 2MB, it works out to be 128kB for a 32^3 cube
@@ -125,7 +128,7 @@ public class PacketCubes {
     private List<int[]> fillBiomeData() {
         List<int[]> dataArrays = new ArrayList<>(cubes.length);
         for (BigCube cube : cubes) {
-            CubeBiomeContainer cubeBiomeContainer = cube.getCubeBiomes();
+            ChunkBiomeContainer cubeBiomeContainer = cube.getBiomes();
             if (cubeBiomeContainer != null) {
                 dataArrays.add(cubeBiomeContainer.writeBiomes());
             } else {
@@ -150,7 +153,8 @@ public class PacketCubes {
                 int z = pos.getZ();
 
                 CubeBiomeContainer cubeBiomeContainer =
-                    new CubeBiomeContainer(Minecraft.getInstance().level.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY), packet.biomeDataArrays.get(i));
+                    new CubeBiomeContainer(Minecraft.getInstance().level.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY),
+                        new CubeSerializer.CubeBoundsLevelHeightAccessor(IBigCube.DIAMETER_IN_BLOCKS, pos.minCubeY(), (CubicLevelHeightAccessor) world), packet.biomeDataArrays.get(i));
 
                 ((IClientCubeProvider) world.getChunkSource()).replaceWithPacketData(
                     x, y, z, cubeBiomeContainer, dataReader, new CompoundTag(), cubeExists.get(i));

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/world/CubicNaturalSpawner.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/world/CubicNaturalSpawner.java
@@ -4,14 +4,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.function.Consumer;
 
-import io.github.opencubicchunks.cubicchunks.chunk.cube.BigCube;
 import io.github.opencubicchunks.cubicchunks.mixin.access.common.NaturalSpawnerAccess;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.NaturalSpawner;
-import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.NearestNeighborBiomeZoomer;
 import net.minecraft.world.level.chunk.ChunkAccess;
 
 @SuppressWarnings("JavaReflectionMemberAccess")
@@ -36,7 +33,7 @@ public class CubicNaturalSpawner {
 
     public static boolean isRightDistanceToPlayerAndSpawnPoint(ServerLevel world, ChunkAccess chunk, BlockPos.MutableBlockPos pos, double squaredDistance) {
         try {
-           return (boolean) IS_RIGHT_DISTANCE_TO_PLAYER_AND_SPAWN_POINT_FOR_CUBE.invoke(null, world, chunk, pos, squaredDistance);
+            return (boolean) IS_RIGHT_DISTANCE_TO_PLAYER_AND_SPAWN_POINT_FOR_CUBE.invoke(null, world, chunk, pos, squaredDistance);
         } catch (IllegalAccessException e) {
             throw new Error(e);
         } catch (InvocationTargetException e) {
@@ -57,10 +54,6 @@ public class CubicNaturalSpawner {
         } catch (InvocationTargetException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public static Biome getRoughBiomeForCube(BlockPos pos, ChunkAccess chunk) {
-        return NearestNeighborBiomeZoomer.INSTANCE.getBiome(0L, pos.getX(), pos.getY(), pos.getZ(), ((BigCube) chunk).getCubeBiomes());
     }
 
     static {


### PR DESCRIPTION
This makes it no longer a separate object and it now extends the vanilla object.

 -This makes Cubic Chunks more compatible with mods who may do something different when setting the ChunkBiomeContainer and allows us to use their "getNoiseBiome" logic