### PR TITLE
Optimizations to aquifers, noise sampling, and random number generation

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/AquiferRandom.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/AquiferRandom.java
@@ -20,9 +20,29 @@ public final class AquiferRandom extends WorldgenRandom {
     }
 
     @Override
+    public int nextInt(int bound) {
+        // simplify method for aquifer's case to encourage inlining
+        // namely, we remove the check for power of two bounds
+
+        int bits;
+        int result;
+        int mod = bound - 1;
+
+        do {
+            long nextSeed = (this.seed * MULTIPLIER + ADDEND) & MASK;
+            this.seed = nextSeed;
+            bits = (int) (nextSeed >>> (48 - 31));
+
+            result = bits % bound;
+        } while (bits + mod < result);
+
+        return result;
+    }
+
+    @Override
     public int next(int bits) {
-        long localSeed = (this.seed * MULTIPLIER + ADDEND) & MASK;
-        this.seed = localSeed;
-        return (int) (localSeed >>> (48 - bits));
+        long nextSeed = (this.seed * MULTIPLIER + ADDEND) & MASK;
+        this.seed = nextSeed;
+        return (int) (nextSeed >>> (48 - bits));
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/AquiferRandom.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/AquiferRandom.java
@@ -1,24 +1,6 @@
 package io.github.opencubicchunks.cubicchunks.chunk;
 
-import net.minecraft.world.level.levelgen.WorldgenRandom;
-
-public final class AquiferRandom extends WorldgenRandom {
-    // duplicated from Random
-    private static final long MULTIPLIER = 0x5DEECE66DL;
-    private static final long ADDEND = 0xBL;
-    private static final long MASK = (1L << 48) - 1;
-
-    private long seed;
-
-    public AquiferRandom() {
-        super(0);
-    }
-
-    @Override
-    public void setSeed(long seed) {
-        this.seed = seed;
-    }
-
+public final class AquiferRandom extends NonAtomicWorldgenRandom {
     @Override
     public int nextInt(int bound) {
         // simplify method for aquifer's case to encourage inlining
@@ -37,12 +19,5 @@ public final class AquiferRandom extends WorldgenRandom {
         } while (bits + mod < result);
 
         return result;
-    }
-
-    @Override
-    public int next(int bits) {
-        long nextSeed = (this.seed * MULTIPLIER + ADDEND) & MASK;
-        this.seed = nextSeed;
-        return (int) (nextSeed >>> (48 - bits));
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/NoiseAndSurfaceBuilderHelper.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/NoiseAndSurfaceBuilderHelper.java
@@ -36,6 +36,8 @@ public class NoiseAndSurfaceBuilderHelper extends ProtoChunk implements CubicLev
     private final boolean generates2DChunks;
     private final WorldStyle worldStyle;
 
+    private final BlockPos.MutableBlockPos mutablePos = new BlockPos.MutableBlockPos();
+
     public NoiseAndSurfaceBuilderHelper(IBigCube delegate, IBigCube delegateAbove) {
         super(delegate.getCubePos().asChunkPos(), UpgradeData.EMPTY, new HeightAccessor(delegate));
         this.delegates = new ChunkAccess[2];
@@ -148,9 +150,11 @@ public class NoiseAndSurfaceBuilderHelper extends ProtoChunk implements CubicLev
     }
 
     private BlockPos correctPos(BlockPos pos) {
-        int x = Coords.blockToSectionLocal(pos.getX()) + Coords.sectionToMinBlock(columnX);
-        int z = Coords.blockToSectionLocal(pos.getZ()) + Coords.sectionToMinBlock(columnZ);
-        return new BlockPos(x, pos.getY(), z);
+        return this.mutablePos.set(
+            Coords.blockToSectionLocal(pos.getX()) + Coords.sectionToMinBlock(columnX),
+            pos.getY(),
+            Coords.blockToSectionLocal(pos.getZ()) + Coords.sectionToMinBlock(columnZ)
+        );
     }
 
     @Override public BlockState getBlockState(BlockPos blockPos) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/NonAtomicWorldgenRandom.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/NonAtomicWorldgenRandom.java
@@ -1,0 +1,33 @@
+package io.github.opencubicchunks.cubicchunks.chunk;
+
+import net.minecraft.world.level.levelgen.WorldgenRandom;
+
+public class NonAtomicWorldgenRandom extends WorldgenRandom {
+    // duplicated from Random
+    protected static final long MULTIPLIER = 0x5DEECE66DL;
+    protected static final long ADDEND = 0xBL;
+    protected static final long MASK = (1L << 48) - 1;
+
+    protected long seed;
+
+    public NonAtomicWorldgenRandom() {
+        super(0);
+    }
+
+    public NonAtomicWorldgenRandom(long seed) {
+        super(0);
+        this.seed = seed;
+    }
+
+    @Override
+    public void setSeed(long seed) {
+        this.seed = seed;
+    }
+
+    @Override
+    public int next(int bits) {
+        long nextSeed = (this.seed * MULTIPLIER + ADDEND) & MASK;
+        this.seed = nextSeed;
+        return (int) (nextSeed >>> (48 - bits));
+    }
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/NonAtomicWorldgenRandom.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/NonAtomicWorldgenRandom.java
@@ -26,8 +26,20 @@ public class NonAtomicWorldgenRandom extends WorldgenRandom {
 
     @Override
     public int next(int bits) {
-        long nextSeed = (this.seed * MULTIPLIER + ADDEND) & MASK;
+        long nextSeed = next(this.seed);
         this.seed = nextSeed;
-        return (int) (nextSeed >>> (48 - bits));
+        return sample(nextSeed, bits);
+    }
+
+    public static long next(long seed) {
+        return (seed * MULTIPLIER + ADDEND) & MASK;
+    }
+
+    public static int sample(long seed, int bits) {
+        return (int) (seed >>> (48 - bits));
+    }
+
+    public static float sampleFloat(long seed) {
+        return sample(seed, 24) / (float) (1 << 24);
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/NonAtomicWorldgenRandom.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/NonAtomicWorldgenRandom.java
@@ -16,12 +16,12 @@ public class NonAtomicWorldgenRandom extends WorldgenRandom {
 
     public NonAtomicWorldgenRandom(long seed) {
         super(0);
-        this.seed = seed;
+        this.seed = scramble(seed);
     }
 
     @Override
     public void setSeed(long seed) {
-        this.seed = seed;
+        this.seed = scramble(seed);
     }
 
     @Override
@@ -29,6 +29,10 @@ public class NonAtomicWorldgenRandom extends WorldgenRandom {
         long nextSeed = next(this.seed);
         this.seed = nextSeed;
         return sample(nextSeed, bits);
+    }
+
+    public static long scramble(long seed) {
+        return (seed ^ MULTIPLIER) & MASK;
     }
 
     public static long next(long seed) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinBlendedNoise.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinBlendedNoise.java
@@ -1,0 +1,105 @@
+package io.github.opencubicchunks.cubicchunks.mixin.core.common.chunk;
+
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.levelgen.synth.BlendedNoise;
+import net.minecraft.world.level.levelgen.synth.PerlinNoise;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(BlendedNoise.class)
+public class MixinBlendedNoise {
+    @Shadow private PerlinNoise mainNoise;
+    @Shadow private PerlinNoise minLimitNoise;
+    @Shadow private PerlinNoise maxLimitNoise;
+
+    /**
+     * @reason optimization: the main noise is often clamped, causing only one of the min limit or max limit to be actually used
+     * @author Gegy
+     */
+    @Overwrite
+    public double sampleAndClampNoise(int ix, int iy, int iz, double horizontalScale, double verticalScale, double horizontalStretch, double verticalStretch) {
+        double amplitude = 1.0;
+
+        double x = ix;
+        double y = iy;
+        double z = iz;
+
+        double main = 0.0;
+        PerlinNoise mainNoise = this.mainNoise;
+
+        for (int octave = 0; octave < 8; octave++) {
+            double unwrappedY = y * verticalStretch;
+            double sampleX = PerlinNoise.wrap(x * horizontalStretch);
+            double sampleY = PerlinNoise.wrap(unwrappedY);
+            double sampleZ = PerlinNoise.wrap(z * horizontalStretch);
+            main += mainNoise.getOctaveNoise(octave).noise(sampleX, sampleY, sampleZ, verticalStretch, unwrappedY) * amplitude;
+
+            horizontalStretch *= 0.5;
+            verticalStretch *= 0.5;
+            amplitude *= 2.0;
+        }
+
+        double mix = (main / 10.0 + 1.0) / 2.0;
+
+        PerlinNoise minLimitNoise = this.minLimitNoise;
+        PerlinNoise maxLimitNoise = this.maxLimitNoise;
+
+        amplitude = 1.0 / 512.0;
+
+        if (mix <= 0.0) {
+            double minLimit = 0.0;
+
+            for (int octave = 0; octave < 16; octave++) {
+                double unwrappedY = y * verticalScale;
+                double sampleX = PerlinNoise.wrap(x * horizontalScale);
+                double sampleY = PerlinNoise.wrap(unwrappedY);
+                double sampleZ = PerlinNoise.wrap(z * horizontalScale);
+
+                minLimit += minLimitNoise.getOctaveNoise(octave).noise(sampleX, sampleY, sampleZ, verticalScale, unwrappedY) * amplitude;
+
+                horizontalScale *= 0.5;
+                verticalScale *= 0.5;
+                amplitude *= 2.0;
+            }
+
+            return minLimit;
+        } else if (mix >= 1.0) {
+            double maxLimit = 0.0;
+
+            for (int octave = 0; octave < 16; octave++) {
+                double unwrappedY = y * verticalScale;
+                double sampleX = PerlinNoise.wrap(x * horizontalScale);
+                double sampleY = PerlinNoise.wrap(unwrappedY);
+                double sampleZ = PerlinNoise.wrap(z * horizontalScale);
+
+                maxLimit += maxLimitNoise.getOctaveNoise(octave).noise(sampleX, sampleY, sampleZ, verticalScale, unwrappedY) * amplitude;
+
+                horizontalScale *= 0.5;
+                verticalScale *= 0.5;
+                amplitude *= 2.0;
+            }
+
+            return maxLimit;
+        } else {
+            double minLimit = 0.0;
+            double maxLimit = 0.0;
+
+            for (int octave = 0; octave < 16; octave++) {
+                double unwrappedY = y * verticalScale;
+                double sampleX = PerlinNoise.wrap(x * horizontalScale);
+                double sampleY = PerlinNoise.wrap(unwrappedY);
+                double sampleZ = PerlinNoise.wrap(z * horizontalScale);
+
+                minLimit += minLimitNoise.getOctaveNoise(octave).noise(sampleX, sampleY, sampleZ, verticalScale, unwrappedY) * amplitude;
+                maxLimit += maxLimitNoise.getOctaveNoise(octave).noise(sampleX, sampleY, sampleZ, verticalScale, unwrappedY) * amplitude;
+
+                horizontalScale *= 0.5;
+                verticalScale *= 0.5;
+                amplitude *= 2.0;
+            }
+
+            return Mth.lerp(mix, minLimit, maxLimit);
+        }
+    }
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkGenerator.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 
 import io.github.opencubicchunks.cubicchunks.chunk.IBigCube;
 import io.github.opencubicchunks.cubicchunks.chunk.ICubeGenerator;
+import io.github.opencubicchunks.cubicchunks.chunk.NonAtomicWorldgenRandom;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
 import io.github.opencubicchunks.cubicchunks.mixin.access.common.OverworldBiomeSourceAccess;
 import io.github.opencubicchunks.cubicchunks.server.CubicLevelHeightAccessor;
@@ -33,6 +34,7 @@ import net.minecraft.world.level.biome.OverworldBiomeSource;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.levelgen.StructureSettings;
+import net.minecraft.world.level.levelgen.WorldgenRandom;
 import net.minecraft.world.level.levelgen.feature.ConfiguredStructureFeature;
 import net.minecraft.world.level.levelgen.feature.StructureFeature;
 import net.minecraft.world.level.levelgen.feature.configurations.StructureFeatureConfiguration;
@@ -45,6 +47,7 @@ import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
@@ -243,5 +246,11 @@ public abstract class MixinChunkGenerator implements ICubeGenerator {
                 }
             }
         }
+    }
+
+    // replace with non-atomic random for optimized random number generation
+    @Redirect(method = "applyCarvers", at = @At(value = "NEW", target = "net/minecraft/world/level/levelgen/WorldgenRandom"))
+    private WorldgenRandom createCarverRandom() {
+        return new NonAtomicWorldgenRandom();
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinDepthBasedReplacingBaseStoneSource.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinDepthBasedReplacingBaseStoneSource.java
@@ -44,7 +44,8 @@ public class MixinDepthBasedReplacingBaseStoneSource {
         } else if (probability >= 1) {
             cir.setReturnValue(this.replacementBlock);
         } else {
-            long seed = NonAtomicWorldgenRandom.next(x * this.seedX ^ y * this.seedY ^ z * this.seedZ ^ this.seed);
+            long seed = NonAtomicWorldgenRandom.scramble(x * this.seedX ^ y * this.seedY ^ z * this.seedZ ^ this.seed);
+            seed = NonAtomicWorldgenRandom.next(seed);
             float sample = NonAtomicWorldgenRandom.sampleFloat(seed);
             cir.setReturnValue(sample < probability ? this.replacementBlock : this.normalBlock);
         }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinDepthBasedReplacingBaseStoneSource.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinDepthBasedReplacingBaseStoneSource.java
@@ -1,5 +1,6 @@
 package io.github.opencubicchunks.cubicchunks.mixin.core.common.chunk;
 
+import io.github.opencubicchunks.cubicchunks.chunk.NonAtomicWorldgenRandom;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.DepthBasedReplacingBaseStoneSource;
@@ -7,7 +8,6 @@ import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.minecraft.world.level.levelgen.WorldgenRandom;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -21,7 +21,7 @@ public class MixinDepthBasedReplacingBaseStoneSource {
     @Shadow @Final private BlockState replacementBlock;
 
     @Shadow @Final private long seed;
-    @Mutable @Shadow @Final private WorldgenRandom random;
+    @Shadow @Final private WorldgenRandom random;
 
     private long seedX, seedY, seedZ;
 
@@ -44,9 +44,9 @@ public class MixinDepthBasedReplacingBaseStoneSource {
         } else if (probability >= 1) {
             cir.setReturnValue(this.replacementBlock);
         } else {
-            long seed = x * this.seedX ^ y * this.seedY ^ z * this.seedZ ^ this.seed;
-            this.random.setSeed(seed);
-            cir.setReturnValue(this.random.nextFloat() < probability ? this.replacementBlock : this.normalBlock);
+            long seed = NonAtomicWorldgenRandom.next(x * this.seedX ^ y * this.seedY ^ z * this.seedZ ^ this.seed);
+            float sample = NonAtomicWorldgenRandom.sampleFloat(seed);
+            cir.setReturnValue(sample < probability ? this.replacementBlock : this.normalBlock);
         }
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinDepthBasedReplacingBaseStoneSource.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinDepthBasedReplacingBaseStoneSource.java
@@ -7,6 +7,7 @@ import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.minecraft.world.level.levelgen.WorldgenRandom;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -16,13 +17,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(DepthBasedReplacingBaseStoneSource.class)
 public class MixinDepthBasedReplacingBaseStoneSource {
 
+    @Shadow @Final private BlockState normalBlock;
     @Shadow @Final private BlockState replacementBlock;
 
-    @Shadow @Final private WorldgenRandom random;
-
-    @Shadow @Final private BlockState normalBlock;
-
     @Shadow @Final private long seed;
+    @Mutable @Shadow @Final private WorldgenRandom random;
 
     private long seedX, seedY, seedZ;
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinNoiseBasedChunkGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinNoiseBasedChunkGenerator.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
+import io.github.opencubicchunks.cubicchunks.chunk.NonAtomicWorldgenRandom;
 import io.github.opencubicchunks.cubicchunks.mixin.access.common.NoiseGeneratorSettingsAccess;
 import io.github.opencubicchunks.cubicchunks.server.CubicLevelHeightAccessor;
 import net.minecraft.util.Mth;
@@ -18,6 +19,7 @@ import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
 import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.minecraft.world.level.levelgen.NoiseSampler;
 import net.minecraft.world.level.levelgen.NoiseSettings;
+import net.minecraft.world.level.levelgen.WorldgenRandom;
 import net.minecraft.world.level.levelgen.synth.NormalNoise;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -144,5 +146,11 @@ public abstract class MixinNoiseBasedChunkGenerator {
             ci.cancel();
             ci.setReturnValue(stoneSource.getBaseStone(x, y, z, this.settings.get()));
         }
+    }
+
+    // replace with non-atomic random for optimized random number generation
+    @Redirect(method = "buildSurfaceAndBedrock", at = @At(value = "NEW", target = "net/minecraft/world/level/levelgen/WorldgenRandom"))
+    private WorldgenRandom createCarverRandom() {
+        return new NonAtomicWorldgenRandom();
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinNoiseBasedChunkGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinNoiseBasedChunkGenerator.java
@@ -150,7 +150,6 @@ public abstract class MixinNoiseBasedChunkGenerator {
                                 double density) {
         // optimization: we don't need to compute aquifer if we know that this block is already solid
         if (density > 0.0) {
-            ci.cancel();
             ci.setReturnValue(stoneSource.getBaseStone(x, y, z, this.settings.get()));
         }
     }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/cave/MixinAquifer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/cave/MixinAquifer.java
@@ -1,20 +1,268 @@
 package io.github.opencubicchunks.cubicchunks.mixin.core.common.chunk.cave;
 
 import io.github.opencubicchunks.cubicchunks.chunk.AquiferRandom;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.levelgen.Aquifer;
-import net.minecraft.world.level.levelgen.WorldgenRandom;
+import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
+import net.minecraft.world.level.levelgen.NoiseSampler;
+import net.minecraft.world.level.levelgen.synth.NormalNoise;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Aquifer.class)
 public abstract class MixinAquifer {
+    @Shadow @Final private NormalNoise barrierNoise;
+
+    @Shadow @Final private int minGridY;
+    @Shadow @Final private long[] aquiferLocationCache;
+    @Mutable @Shadow @Final private int[] aquiferCache;
+
+    @Shadow private boolean shouldScheduleWaterUpdate;
+    @Shadow private int lastWaterLevel;
+    @Shadow private double lastBarrierDensity;
+
+    @Shadow protected abstract int gridY(int i);
+    @Shadow protected abstract int getIndex(int x, int y, int z);
+    @Shadow protected abstract double similarity(int i, int j);
+    @Shadow protected abstract int computeAquifer(int x, int y, int z);
+
+    private static final double NOISE_MIN = transformBarrierNoise(-1.5);
+    private static final double NOISE_MAX = transformBarrierNoise(1.5);
+
+    private static double transformBarrierNoise(double noise) {
+        return 1.0 + (noise + 0.1) / 4.0;
+    }
+
     private final AquiferRandom random = new AquiferRandom();
 
-    // optimization: don't create a new random instance every time
-    @Redirect(method = "computeAt", at = @At(value = "NEW", target = "net/minecraft/world/level/levelgen/WorldgenRandom"))
-    private WorldgenRandom createRandom(long seed) {
-        this.random.setSeed(seed);
-        return this.random;
+    private double barrierNoiseCache = Double.NaN;
+
+    private int minLevelGridX;
+    private int minLevelGridZ;
+    private int levelGridSizeX;
+    private int levelGridSizeZ;
+
+    @Inject(method = "<init>", at = @At(value = "INVOKE", target = "Ljava/util/Arrays;fill([II)V", shift = At.Shift.BEFORE, remap = false))
+    private void init(int chunkX, int chunkZ, NormalNoise barrierNoise, NormalNoise waterLevelNoise, NoiseGeneratorSettings noiseSettings, NoiseSampler sampler, int sizeY, CallbackInfo ci) {
+        int minX = chunkX << 4;
+        int maxX = (chunkX << 4) + 15;
+        int minZ = chunkZ << 4;
+        int maxZ = (chunkZ << 4) + 15;
+        int minY = noiseSettings.noiseSettings().minY();
+
+        int minGridX = levelGridX(minX) - 1;
+        int maxGridX = levelGridX(maxX) + 1;
+        int minGridY = this.gridY(minY) - 1;
+        int maxGridY = this.gridY(minY + sizeY) + 1;
+        int minGridZ = levelGridZ(minZ) - 1;
+        int maxGridZ = levelGridZ(maxZ) + 1;
+
+        this.minLevelGridX = minGridX;
+        this.levelGridSizeX = maxGridX - minGridX + 1;
+        this.minLevelGridZ = minGridZ;
+        this.levelGridSizeZ = maxGridZ - minGridZ + 1;
+
+        int gridSizeY = maxGridY - minGridY + 1;
+        int levelCacheSize = this.levelGridSizeX * gridSizeY * this.levelGridSizeZ;
+
+        // TODO: we have to reinitialize the array because we can't redirect int array construction.. what other options?
+        this.aquiferCache = new int[levelCacheSize];
+    }
+
+    private static int levelGridX(int x) {
+        return x >> 6;
+    }
+
+    private static int levelGridZ(int z) {
+        return z >> 6;
+    }
+
+    // we aren't able to reduce the grid on the y-axis because they don't match; can we change this?
+    private int getLevelIndex(int x, int y, int z) {
+        int localX = x - this.minLevelGridX;
+        int localY = y - this.minGridY;
+        int localZ = z - this.minLevelGridZ;
+        return (localY * this.levelGridSizeZ + localZ) * this.levelGridSizeX + localX;
+    }
+
+    /**
+     * @reason lazily compute barrier noise value to avoid excessive sampling
+     * @author Gegy
+     */
+    @Overwrite
+    protected void computeAt(int x, int y, int z) {
+        int gridX = this.gridX(x - 5);
+        int gridY = this.gridY(y + 1);
+        int gridZ = this.gridZ(z - 5);
+
+        // find closest 3 aquifer sources
+        int closestDistance2 = Integer.MAX_VALUE;
+        int secondDistance2 = Integer.MAX_VALUE;
+        int thirdDistance2 = Integer.MAX_VALUE;
+        long closestSource = 0;
+        long secondSource = 0;
+        long thirdSource = 0;
+
+        for (int offsetX = 0; offsetX <= 1; offsetX++) {
+            for (int offsetY = -1; offsetY <= 1; offsetY++) {
+                for (int offsetZ = 0; offsetZ <= 1; offsetZ++) {
+                    long sourcePos = this.getAquiferSourceIn(gridX + offsetX, gridY + offsetY, gridZ + offsetZ);
+
+                    int deltaX = BlockPos.getX(sourcePos) - x;
+                    int deltaY = BlockPos.getY(sourcePos) - y;
+                    int deltaZ = BlockPos.getZ(sourcePos) - z;
+
+                    int distance2 = deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ;
+                    if (distance2 <= closestDistance2) {
+                        thirdSource = secondSource;
+                        secondSource = closestSource;
+                        closestSource = sourcePos;
+                        thirdDistance2 = secondDistance2;
+                        secondDistance2 = closestDistance2;
+                        closestDistance2 = distance2;
+                    } else if (distance2 <= secondDistance2) {
+                        thirdSource = secondSource;
+                        secondSource = sourcePos;
+                        thirdDistance2 = secondDistance2;
+                        secondDistance2 = distance2;
+                    } else if (distance2 <= thirdDistance2) {
+                        thirdSource = sourcePos;
+                        thirdDistance2 = distance2;
+                    }
+                }
+            }
+        }
+
+        int closestWaterLevel = this.getWaterLevel(closestSource);
+        int secondWaterLevel = this.getWaterLevel(secondSource);
+        int thirdWaterLevel = this.getWaterLevel(thirdSource);
+
+        double closestToSecond = this.similarity(closestDistance2, secondDistance2);
+
+        this.lastWaterLevel = closestWaterLevel;
+        this.shouldScheduleWaterUpdate = closestToSecond > 0.0;
+
+        if (closestToSecond <= -1.0) {
+            this.lastBarrierDensity = 0.0;
+            return;
+        }
+
+        // find barrier density
+        double closestToThird = this.similarity(closestDistance2, thirdDistance2);
+        double secondToThird = this.similarity(secondDistance2, thirdDistance2);
+
+        // early exit: we know density will = 0
+        if (closestToSecond <= 0.0 && secondToThird <= 0.0 && closestToThird <= 0.0) {
+            this.lastBarrierDensity = 0.0;
+            return;
+        }
+
+        this.barrierNoiseCache = Double.NaN;
+
+        double closestToSecondPressure = this.getPressureLazyNoise(x, y, z, closestWaterLevel, secondWaterLevel);
+        double closestToThirdPressure = this.getPressureLazyNoise(x, y, z, closestWaterLevel, thirdWaterLevel);
+        double secondToThirdPressure = this.getPressureLazyNoise(x, y, z, secondWaterLevel, thirdWaterLevel);
+
+        // early exit: we know density will = 0
+        if (Double.isNaN(this.barrierNoiseCache) || (closestToSecondPressure <= 0.0 && closestToThirdPressure <= 0.0 && secondToThirdPressure <= 0.0)) {
+            this.lastBarrierDensity = 0.0;
+            return;
+        }
+
+        double closestToSecondFactor = Math.max(0.0, closestToSecond);
+        double closestToThirdFactor = Math.max(0.0, closestToThird);
+        double secondClosestToThirdFactor = Math.max(0.0, secondToThird);
+
+        double toThirdPressure = Math.max(
+            closestToThirdPressure * closestToThirdFactor,
+            secondToThirdPressure * secondClosestToThirdFactor
+        );
+
+        this.lastBarrierDensity = Math.max(0.0, 2.0 * closestToSecondFactor * Math.max(closestToSecondPressure, toThirdPressure));
+    }
+
+    private double getPressureLazyNoise(int x, int y, int z, int firstLevel, int secondLevel) {
+        double meanLevel = 0.5 * (firstLevel + secondLevel);
+        double distanceFromMean = Math.abs(meanLevel - y - 0.5);
+
+        double targetDistanceFromMean = 0.5 * Math.abs(firstLevel - secondLevel);
+
+        // avoid sampling noise if we don't need it
+        double noise = this.barrierNoiseCache;
+        if (Double.isNaN(noise)) {
+            if (targetDistanceFromMean * NOISE_MIN <= distanceFromMean && targetDistanceFromMean * NOISE_MAX <= distanceFromMean) {
+                return 0.0;
+            }
+
+            this.barrierNoiseCache = noise = transformBarrierNoise(this.barrierNoise.getValue(x, y, z));
+        }
+
+        return (targetDistanceFromMean * noise) - distanceFromMean;
+    }
+
+    private long getAquiferSourceIn(int x, int y, int z) {
+        int index = this.getIndex(x, y, z);
+
+        long sourcePos = this.aquiferLocationCache[index];
+        if (sourcePos == Long.MAX_VALUE) {
+            AquiferRandom random = this.random;
+            random.setSeed(Mth.getSeed(x, y * 3, z) + 1L);
+            sourcePos = BlockPos.asLong(
+                x * 16 + random.nextInt(10),
+                y * 12 + random.nextInt(9),
+                z * 16 + random.nextInt(10)
+            );
+            this.aquiferLocationCache[index] = sourcePos;
+        }
+
+        return sourcePos;
+    }
+
+    /**
+     * @reason replace with smaller cache to avoid recomputing the same values
+     * @author Gegy
+     */
+    @Overwrite
+    private int getWaterLevel(long pos) {
+        int x = BlockPos.getX(pos);
+        int y = BlockPos.getY(pos);
+        int z = BlockPos.getZ(pos);
+        int gridX = levelGridX(x);
+        int gridY = this.gridY(y);
+        int gridZ = levelGridZ(z);
+
+        int cacheIndex = this.getLevelIndex(gridX, gridY, gridZ);
+        int level = this.aquiferCache[cacheIndex];
+        if (level == Integer.MAX_VALUE) {
+            level = this.computeAquifer(x, y, z);
+            this.aquiferCache[cacheIndex] = level;
+        }
+
+        return level;
+    }
+
+    /**
+     * @reason optimization: shift is faster than floorDiv
+     * @author Gegy
+     */
+    @Overwrite
+    private int gridX(int x) {
+        return x >> 4;
+    }
+
+    /**
+     * @reason optimization: shift is faster than floorDiv
+     * @author Gegy
+     */
+    @Overwrite
+    private int gridZ(int z) {
+        return z >> 4;
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/cave/legacy/MixinCaveWorldCarver.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/cave/legacy/MixinCaveWorldCarver.java
@@ -4,6 +4,7 @@ import java.util.BitSet;
 import java.util.Random;
 import java.util.function.Function;
 
+import io.github.opencubicchunks.cubicchunks.chunk.NonAtomicWorldgenRandom;
 import io.github.opencubicchunks.cubicchunks.server.CubicLevelHeightAccessor;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.biome.Biome;
@@ -52,5 +53,10 @@ public abstract class MixinCaveWorldCarver {
         } else {
             return random.nextInt(random.nextInt(chunk.getHeight()) + 1);
         }
+    }
+
+    @Redirect(method = "genTunnel", at = @At(value = "NEW", target = "java/util/Random", remap = false))
+    private Random createRandom(long seed) {
+        return new NonAtomicWorldgenRandom(seed);
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/cave/legacy/MixinWorldCarver.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/cave/legacy/MixinWorldCarver.java
@@ -4,6 +4,7 @@ import java.util.BitSet;
 import java.util.Random;
 import java.util.function.Function;
 
+import io.github.opencubicchunks.cubicchunks.chunk.NonAtomicWorldgenRandom;
 import io.github.opencubicchunks.cubicchunks.chunk.carver.GenHeightSetter;
 import io.github.opencubicchunks.cubicchunks.server.CubicLevelHeightAccessor;
 import net.minecraft.core.BlockPos;
@@ -82,5 +83,10 @@ public class MixinWorldCarver implements GenHeightSetter {
         if (y >= chunk.getMaxBuildHeight() || y < chunk.getMinBuildHeight()) {
             cir.setReturnValue(false);
         }
+    }
+
+    @Redirect(method = "carveSphere", at = @At(value = "NEW", target = "java/util/Random", remap = false))
+    private Random createRandom(long seed) {
+        return new NonAtomicWorldgenRandom(seed);
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/world/CubeWorldGenRandom.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/world/CubeWorldGenRandom.java
@@ -1,9 +1,8 @@
 package io.github.opencubicchunks.cubicchunks.world;
 
-import net.minecraft.world.level.levelgen.WorldgenRandom;
+import io.github.opencubicchunks.cubicchunks.chunk.NonAtomicWorldgenRandom;
 
-public class CubeWorldGenRandom extends WorldgenRandom {
-
+public class CubeWorldGenRandom extends NonAtomicWorldgenRandom {
     public long setDecorationSeed(long worldSeed, int x, int y, int z) {
         this.setSeed(worldSeed);
         long sX = this.nextLong() | 1L;

--- a/src/main/resources/cubicchunks.mixins.core.json
+++ b/src/main/resources/cubicchunks.mixins.core.json
@@ -80,7 +80,8 @@
         "common.world.surfacebuilder.MixinErodedBadlandsSurfaceBuilder",
         "common.world.surfacebuilder.MixinFrozenOceanSurfaceBuilder",
         "common.world.surfacebuilder.MixinSwampSurfaceBuilder",
-        "common.world.surfacebuilder.MixinWoodedBadlandsSurfaceBuilder"
+        "common.world.surfacebuilder.MixinWoodedBadlandsSurfaceBuilder",
+        "common.chunk.MixinBlendedNoise"
     ],
     "client": [
         "client.chunk.MixinRenderChunkRegion",


### PR DESCRIPTION
This is quite a generally invasive PR addressing a wide range of targets. Most significant though are the optimizations to aquifers, which has been reduced from ~20% CPU time during generation to ~2%.

Loading a world with 12 threads:
- Pre-optimizations: 42.3s
- Post-optimizations: 37.5s

Loading a world with 2 threads:
- Pre-optimizations: 110.2s
- Post-optimizations: 80.9s