### PR TITLE
Add another status renderer option for debugging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,9 @@ minecraft {
             "-Dmixin.debug.export=true",
             "-Dmixin.checks.interfaces=true",
             "-Dcubicchunks.debug=false",
-            "-Dcubicchunks.debug.mixins=false",
+            "-Dcubicchunks.debug.loadorder=false",
+            "-Dcubicchunks.debug.window=false",
+            "-Dcubicchunks.debug.statusrenderer=false",
             "-Dcubicchunks.debug.biomes=false",
     ]
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/DebugMixinConfig.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/DebugMixinConfig.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 
 public class DebugMixinConfig implements IMixinConfigPlugin {
 
-    private static final boolean DEBUG_MIXINS_ENABLED = System.getProperty("cubicchunks.debug.mixins", "false").equals("true");
+    private static final boolean DEBUG_MIXINS_ENABLED = System.getProperty("cubicchunks.debug", "false").equals("true");
 
     @Override public void onLoad(String mixinPackage) {
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/debug/MixinGameRenderer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/debug/MixinGameRenderer.java
@@ -12,9 +12,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GameRenderer.class)
 public class MixinGameRenderer {
+    private static final boolean DEBUG_WINDOW_ENABLED = System.getProperty("cubicchunks.debug.window", "false").equals("true");
+
     @Inject(method = "renderLevel", at = @At("RETURN"))
     private void onRender(float f, long l, PoseStack poseStack, CallbackInfo ci) {
-        if (!((CubicLevelHeightAccessor) Minecraft.getInstance().level).isCubic()) {
+        if (!((CubicLevelHeightAccessor) Minecraft.getInstance().level).isCubic() || !DEBUG_WINDOW_ENABLED) {
             return;
         }
         DebugVisualization.onRender();

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/client/MixinLevelRenderer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/client/MixinLevelRenderer.java
@@ -1,0 +1,125 @@
+package io.github.opencubicchunks.cubicchunks.mixin.debug.client;
+
+import java.lang.reflect.Field;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.math.Matrix4f;
+import com.mojang.math.Vector3f;
+import io.github.opencubicchunks.cubicchunks.chunk.IBigCube;
+import io.github.opencubicchunks.cubicchunks.server.ICubicWorld;
+import io.github.opencubicchunks.cubicchunks.utils.Coords;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.LevelLoadingScreen;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.LightTexture;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.ChunkStatus;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LevelRenderer.class)
+public class MixinLevelRenderer {
+    private static final boolean doDebugRender = System.getProperty("cubicchunks.debug.statusrenderer", "false").equalsIgnoreCase("true");
+
+    @Inject(method = "renderLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/debug/DebugRenderer;"
+        + "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;DDD)V"))
+    public void render(PoseStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightTexture lightTexture,
+                       Matrix4f matrix4f, CallbackInfo ci) {
+        if(!doDebugRender)
+            return;
+
+        ServerLevel levelAccessor = Minecraft.getInstance().getSingleplayerServer().getLevel(Level.OVERWORLD);
+        RenderSystem.disableBlend();
+        RenderSystem.disableTexture();
+        RenderSystem.enableDepthTest();
+        RenderSystem.setShader(GameRenderer::getPositionColorShader);
+        double cameraX = camera.getPosition().x;
+        double cameraY = camera.getPosition().y;
+        double cameraZ = camera.getPosition().z;
+        BlockPos blockPos = new BlockPos(cameraX, cameraY, cameraZ);
+        Tesselator tesselator = Tesselator.getInstance();
+        BufferBuilder bufferBuilder = tesselator.getBuilder();
+        bufferBuilder.begin(VertexFormat.Mode.TRIANGLE_STRIP, DefaultVertexFormat.POSITION_COLOR);
+
+        Object2IntMap<ChunkStatus> colors = getField(
+            LevelLoadingScreen.class, null, "COLORS" // TODO: intermediary name
+        );
+
+        int renderRadius = 5;
+
+        int chunkRenderRadius = renderRadius * IBigCube.DIAMETER_IN_SECTIONS;
+        for (int x = -chunkRenderRadius; x <= chunkRenderRadius; ++x) {
+            for (int z = -chunkRenderRadius; z <= chunkRenderRadius; ++z) {
+                BlockPos offset = blockPos.offset(x * 16, 0, z * 16);
+                int color = 0;
+                int chunkX = offset.getX() >> 4;
+                int chunkZ = offset.getZ() >> 4;
+                ChunkAccess chunkAccess = levelAccessor.getChunk(chunkX, chunkZ, ChunkStatus.EMPTY, false);
+                if (chunkAccess != null) {
+                    ChunkStatus status = chunkAccess.getStatus();
+                    color = colors.getOrDefault(status, 0);
+                }
+
+                Vector3f vector3f = new Vector3f(((color >> 16) & 0xff) / 256f, ((color >> 8) & 0xff) / 256f, (color & 0xff) / 256f); //this.getColor(types);
+
+                int xPos = SectionPos.sectionToBlockCoord(chunkX, 0);
+                int zPos = SectionPos.sectionToBlockCoord(chunkZ, 0);
+                LevelRenderer.addChainedFilledBoxVertices(bufferBuilder, xPos + 4.25F - cameraX, 108 - cameraY, zPos + 4.25F - cameraZ, xPos + 11.75F - cameraX, 108 - cameraY + 0.09375F,
+                    zPos + 11.75F - cameraZ, vector3f.x(), vector3f.y(), vector3f.z(), 1.0F);
+            }
+        }
+
+        for (int x = -renderRadius; x <= renderRadius; ++x) {
+            for (int z = -renderRadius; z <= renderRadius; ++z) {
+                for (int y = -renderRadius; y < renderRadius; y++) {
+                    BlockPos offset = blockPos.offset(x * IBigCube.DIAMETER_IN_BLOCKS, y * IBigCube.DIAMETER_IN_BLOCKS, z * IBigCube.DIAMETER_IN_BLOCKS);
+                    int color = 0;
+                    int cubeX = Coords.blockToCube(offset.getX());
+                    int cubeY = Coords.blockToCube(offset.getY());
+                    int cubeZ = Coords.blockToCube(offset.getZ());
+                    IBigCube cube = ((ICubicWorld) levelAccessor).getCube(cubeX, cubeY, cubeZ, ChunkStatus.EMPTY, false);
+                    if (cube != null) {
+                        ChunkStatus status = cube.getStatus();
+                        color = colors.getOrDefault(status, 0);
+                    }
+
+                    Vector3f vector3f = new Vector3f(((color >> 16) & 0xff) / 256f, ((color >> 8) & 0xff) / 256f, (color & 0xff) / 256f); //this.getColor(types);
+
+                    int xPos = Coords.cubeToMinBlock(cubeX);
+                    int yPos = Coords.cubeToMinBlock(cubeY);
+                    int zPos = Coords.cubeToMinBlock(cubeZ);
+                    LevelRenderer.addChainedFilledBoxVertices(bufferBuilder, xPos + 4.25F - cameraX, yPos - 4.25F - cameraY, zPos + 4.25F - cameraZ,
+                        xPos + 11.75F - cameraX, yPos + 4.25F - cameraY, zPos + 11.75F - cameraZ, vector3f.x(), vector3f.y(), vector3f.z(), 1.0F);
+                }
+            }
+        }
+
+        tesselator.end();
+        RenderSystem.enableTexture();
+    }
+
+    private static <T> T getField(Class<?> cl, Object obj, String name) {
+        try {
+            Field f = cl.getDeclaredField(name);
+            f.setAccessible(true);
+            return (T) f.get(obj);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/client/MixinLevelRenderer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/client/MixinLevelRenderer.java
@@ -24,7 +24,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ChunkStatus;
 import org.spongepowered.asm.mixin.Mixin;
@@ -34,14 +33,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LevelRenderer.class)
 public class MixinLevelRenderer {
-    private static final boolean doDebugRender = System.getProperty("cubicchunks.debug.statusrenderer", "false").equalsIgnoreCase("true");
+    private static final boolean DEBUG_STATUS_RENDERER = System.getProperty("cubicchunks.debug.statusrenderer", "false").equalsIgnoreCase("true");
 
     @Inject(method = "renderLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/debug/DebugRenderer;"
         + "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;DDD)V"))
     public void render(PoseStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightTexture lightTexture,
                        Matrix4f matrix4f, CallbackInfo ci) {
-        if(!doDebugRender)
+        if (!DEBUG_STATUS_RENDERER) {
             return;
+        }
 
         ServerLevel levelAccessor = Minecraft.getInstance().getSingleplayerServer().getLevel(Level.OVERWORLD);
         RenderSystem.disableBlend();

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinDistanceManager.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinDistanceManager.java
@@ -1,0 +1,24 @@
+package io.github.opencubicchunks.cubicchunks.mixin.debug.common;
+
+import net.minecraft.server.level.DistanceManager;
+import net.minecraft.server.level.Ticket;
+import net.minecraft.server.level.TicketType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(DistanceManager.class)
+public class MixinDistanceManager {
+    private static final boolean DEBUG_LOAD_ORDER_ENABLED = System.getProperty("cubicchunks.debug.loadorder", "false").equals("true");
+
+    @Inject(method = "addTicket(JLnet/minecraft/server/level/Ticket;)V", at = @At("HEAD"), cancellable = true)
+    private void cancelPlayerTickets(long position, Ticket<?> ticket, CallbackInfo ci) {
+        if (!DEBUG_LOAD_ORDER_ENABLED) {
+            return;
+        }
+        if (ticket.getType() == TicketType.PLAYER) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinMinecraftServer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinMinecraftServer.java
@@ -46,8 +46,9 @@ public abstract class MixinMinecraftServer {
      */
     @Inject(method = "prepareLevels", at = @At("HEAD"), cancellable = true)
     private void prepareLevels(ChunkProgressListener worldGenerationProgressListener, CallbackInfo ci) {
-        if(!DEBUG_LOAD_ORDER_ENABLED)
+        if (!DEBUG_LOAD_ORDER_ENABLED) {
             return;
+        }
 
         ci.cancel();
         ServerLevel serverLevel = this.overworld();

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinMinecraftServer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinMinecraftServer.java
@@ -26,6 +26,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = MinecraftServer.class, priority = 999)
 public abstract class MixinMinecraftServer {
+    private static final boolean DEBUG_LOAD_ORDER_ENABLED = System.getProperty("cubicchunks.debug.loadorder", "false").equals("true");
+
     @Shadow @Final private static Logger LOGGER;
 
     @Shadow private long nextTickTime;
@@ -44,6 +46,9 @@ public abstract class MixinMinecraftServer {
      */
     @Inject(method = "prepareLevels", at = @At("HEAD"), cancellable = true)
     private void prepareLevels(ChunkProgressListener worldGenerationProgressListener, CallbackInfo ci) {
+        if(!DEBUG_LOAD_ORDER_ENABLED)
+            return;
+
         ci.cancel();
         ServerLevel serverLevel = this.overworld();
         LOGGER.info("Preparing start region for dimension {}", serverLevel.dimension().location());

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinMinecraftServer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinMinecraftServer.java
@@ -3,7 +3,9 @@ package io.github.opencubicchunks.cubicchunks.mixin.debug.common;
 import java.util.Iterator;
 import java.util.Map;
 
-import io.github.opencubicchunks.cubicchunks.server.ICubicWorld;
+import io.github.opencubicchunks.cubicchunks.CubicChunks;
+import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
+import io.github.opencubicchunks.cubicchunks.server.IServerChunkProvider;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
@@ -11,12 +13,12 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.TicketType;
 import net.minecraft.server.level.progress.ChunkProgressListener;
+import net.minecraft.util.Unit;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.ForcedChunksSavedData;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.chunk.ChunkStatus;
-import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -28,17 +30,28 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class MixinMinecraftServer {
     private static final boolean DEBUG_LOAD_ORDER_ENABLED = System.getProperty("cubicchunks.debug.loadorder", "false").equals("true");
 
-    @Shadow @Final private static Logger LOGGER;
-
-    @Shadow private long nextTickTime;
+    private int count = 0;
 
     @Shadow @Final private Map<ResourceKey<Level>, ServerLevel> levels;
+
+    @Shadow private long nextTickTime;
 
     @Shadow protected abstract void waitUntilNextTick();
 
     @Shadow protected abstract void updateMobSpawningFlags();
 
     @Shadow public abstract ServerLevel overworld();
+
+    @Shadow public abstract boolean isRunning();
+
+    private void addChunk(ServerChunkCache serverChunkCache, ChunkPos pos) {
+        serverChunkCache.addRegionTicket(TicketType.START, pos, 1, Unit.INSTANCE);
+        count++;
+    }
+    private void addCube(IServerChunkProvider serverChunkProvider, CubePos pos) {
+        serverChunkProvider.addCubeRegionTicket(TicketType.START, pos, 1, Unit.INSTANCE);
+        count++;
+    }
 
     /**
      * @author NotStirred
@@ -52,35 +65,30 @@ public abstract class MixinMinecraftServer {
 
         ci.cancel();
         ServerLevel serverLevel = this.overworld();
-        LOGGER.info("Preparing start region for dimension {}", serverLevel.dimension().location());
+        CubicChunks.LOGGER.info("Preparing start region for dimension {}", serverLevel.dimension().location());
         BlockPos blockPos = serverLevel.getSharedSpawnPos();
         worldGenerationProgressListener.updateSpawnPos(new ChunkPos(blockPos));
         ServerChunkCache serverChunkCache = serverLevel.getChunkSource();
         serverChunkCache.getLightEngine().setTaskPerBatch(500);
         this.nextTickTime = Util.getMillis();
 
-        overworld().getChunk(0, 0, ChunkStatus.FULL, true);
-        overworld().getChunk(-5, -5, ChunkStatus.FULL, true);
-        overworld().getChunk(-5, 5, ChunkStatus.FULL, true);
-        overworld().getChunk(5, -5, ChunkStatus.FULL, true);
-        overworld().getChunk(5, 5, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(0, 0, 0, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(2, 2, 2, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(-2, 2, 2, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(2, -2, 2, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(2, 2, -2, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(-2, -2, 2, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(2, -2, -2, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(-2, 2, -2, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(-2, -2, -2, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(5, 5, 5, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(-5, 5, 5, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(5, -5, 5, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(5, 5, -5, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(-5, -5, 5, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(5, -5, -5, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(-5, 5, -5, ChunkStatus.FULL, true);
-        ((ICubicWorld) overworld()).getCube(-5, -5, -5, ChunkStatus.FULL, true);
+        IServerChunkProvider prov = (IServerChunkProvider) serverChunkCache;
+        addChunk(serverChunkCache, new ChunkPos(0, 0));
+        addCube(prov, CubePos.of(0, 0, 0));
+
+        addCube(prov, CubePos.of(5, 5, 5));
+        addCube(prov, CubePos.of(-5, 5, 5));
+        addCube(prov, CubePos.of(-5, -5, 5));
+        addCube(prov, CubePos.of(-5, -5, -5));
+        addCube(prov, CubePos.of(5, -5, 5));
+        addCube(prov, CubePos.of(5, -5, -5));
+        addCube(prov, CubePos.of(5, 5, -5));
+        addCube(prov, CubePos.of(-5, 5, -5));
+
+        while (this.isRunning() && (serverChunkCache.getTickingGenerated() + prov.getTickingGeneratedCubes() < count)) {
+            this.nextTickTime = Util.getMillis() + 10L;
+            this.waitUntilNextTick();
+        }
 
         try {
             Thread.sleep(10000);

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinPlayerRespawnLogic.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinPlayerRespawnLogic.java
@@ -10,8 +10,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = PlayerRespawnLogic.class, priority = 999)
 public class MixinPlayerRespawnLogic {
+    private static final boolean DEBUG_LOAD_ORDER_ENABLED = System.getProperty("cubicchunks.debug.loadorder", "false").equals("true");
+
     @Inject(method = "getOverworldRespawnPos", at = @At("HEAD"), cancellable = true)
     private static void fakeRespawnLocation(ServerLevel world, int x, int z, boolean validSpawnNeeded, CallbackInfoReturnable<BlockPos> cir) {
+        if(!DEBUG_LOAD_ORDER_ENABLED)
+            return;
         cir.setReturnValue(new BlockPos(0, 0, 0));
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinPlayerRespawnLogic.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinPlayerRespawnLogic.java
@@ -14,8 +14,9 @@ public class MixinPlayerRespawnLogic {
 
     @Inject(method = "getOverworldRespawnPos", at = @At("HEAD"), cancellable = true)
     private static void fakeRespawnLocation(ServerLevel world, int x, int z, boolean validSpawnNeeded, CallbackInfoReturnable<BlockPos> cir) {
-        if(!DEBUG_LOAD_ORDER_ENABLED)
+        if (!DEBUG_LOAD_ORDER_ENABLED) {
             return;
+        }
         cir.setReturnValue(new BlockPos(0, 0, 0));
     }
 }

--- a/src/main/resources/cubicchunks.mixins.debug.json
+++ b/src/main/resources/cubicchunks.mixins.debug.json
@@ -12,6 +12,7 @@
         "conformVisibility": true
     },
     "mixins": [
+        "common.MixinDistanceManager",
         "common.MixinMinecraftServer",
         "common.MixinPlayerRespawnLogic"
     ],

--- a/src/main/resources/cubicchunks.mixins.debug.json
+++ b/src/main/resources/cubicchunks.mixins.debug.json
@@ -15,6 +15,8 @@
         "common.MixinMinecraftServer",
         "common.MixinPlayerRespawnLogic"
     ],
-    "client": [],
+    "client": [
+        "client.MixinLevelRenderer"
+    ],
     "server": []
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16853282/115174619-79f28000-a0c1-11eb-8dfd-40c65dd60603.png)

squares are chunks, cubes are... cubes.
Accessed with `-Dcubicchunks.debug.statusrenderer`

Also moved the debug window to `-Dcubicchunks.debug.window` and the load order PR to `"-Dcubicchunks.debug.loadorder"`