### PR TITLE
Columns before cubes load order & unload order

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/IChunkManager.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/IChunkManager.java
@@ -15,7 +15,6 @@ import io.github.opencubicchunks.cubicchunks.utils.Coords;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import net.minecraft.core.SectionPos;
 import net.minecraft.server.level.ChunkHolder;
-import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.chunk.ChunkStatus;
 
@@ -121,6 +120,4 @@ public interface IChunkManager {
     void releaseLightTicket(CubePos cubePos);
 
     boolean noPlayersCloseForSpawning(CubePos cubePos);
-
-    void setServerChunkCache(ServerChunkCache cache);
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/IChunkManager.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/IChunkManager.java
@@ -15,6 +15,7 @@ import io.github.opencubicchunks.cubicchunks.utils.Coords;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import net.minecraft.core.SectionPos;
 import net.minecraft.server.level.ChunkHolder;
+import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.chunk.ChunkStatus;
 
@@ -29,6 +30,7 @@ public interface IChunkManager {
     @Nullable
     ChunkHolder updateCubeScheduling(long cubePosIn, int newLevel, @Nullable ChunkHolder holder, int oldLevel);
 
+    void setServerChunkCache(ServerChunkCache cache);
     LongSet getCubesToDrop();
 
     @Nullable

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/ICubeHolder.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/ICubeHolder.java
@@ -34,10 +34,6 @@ public interface ICubeHolder {
         return cubeLevel < 33 ? ChunkStatus.FULL : CubeStatus.getStatus(cubeLevel - 33);
     }
 
-    void setChunkHolders(ChunkHolder[] chunkHolders);
-
-    ChunkHolder[] getChunkHolders();
-
     @Nullable
     BigCube getCubeIfComplete();
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/graph/CCTicketType.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/graph/CCTicketType.java
@@ -5,7 +5,6 @@ import java.util.Comparator;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
 import io.github.opencubicchunks.cubicchunks.mixin.access.common.TicketTypeAccess;
 import net.minecraft.server.level.TicketType;
-import net.minecraft.world.level.ChunkPos;
 
 public class CCTicketType {
     public static final TicketType<CubePos> CCPLAYER = create("player", Comparator.comparingLong(CubePos::asLong));

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/graph/CCTicketType.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/graph/CCTicketType.java
@@ -5,12 +5,15 @@ import java.util.Comparator;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
 import io.github.opencubicchunks.cubicchunks.mixin.access.common.TicketTypeAccess;
 import net.minecraft.server.level.TicketType;
+import net.minecraft.world.level.ChunkPos;
 
 public class CCTicketType {
     public static final TicketType<CubePos> CCPLAYER = create("player", Comparator.comparingLong(CubePos::asLong));
     public static final TicketType<CubePos> CCFORCED = create("forced", Comparator.comparingLong(CubePos::asLong));
     public static final TicketType<CubePos> CCLIGHT = create("light", Comparator.comparingLong(CubePos::asLong));
     public static final TicketType<CubePos> CCUNKNOWN = create("unknown", Comparator.comparingLong(CubePos::asLong), 1);
+
+    public static final TicketType<CubePos> CCCOLUMN = create("column", Comparator.comparingLong(CubePos::asLong));
 
 
     public static <T> TicketType<T> create(String nameIn, Comparator<T> comparator) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/access/common/ChunkManagerAccess.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/access/common/ChunkManagerAccess.java
@@ -16,4 +16,6 @@ public interface ChunkManagerAccess {
     @Invoker boolean invokePromoteChunkMap();
     @Invoker void invokeOnFullChunkStatusChange(ChunkPos chunkPos, ChunkHolder.FullChunkStatus fullChunkStatus);
     @Accessor int getViewDistance();
+
+    @Invoker void invokeReleaseLightTicket(ChunkPos pos);
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/access/common/ThreadedLevelLightEngineAccess.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/access/common/ThreadedLevelLightEngineAccess.java
@@ -1,0 +1,14 @@
+package io.github.opencubicchunks.cubicchunks.mixin.access.common;
+
+import net.minecraft.server.level.ChunkMap;
+import net.minecraft.server.level.ThreadedLevelLightEngine;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(ThreadedLevelLightEngine.class)
+public interface ThreadedLevelLightEngineAccess {
+    @Accessor ChunkMap getChunkMap();
+
+    @Invoker void invokeAddTask(int x, int z, ThreadedLevelLightEngine.TaskType stage, Runnable task);
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/access/common/TicketAccess.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/access/common/TicketAccess.java
@@ -3,6 +3,7 @@ package io.github.opencubicchunks.cubicchunks.mixin.access.common;
 import net.minecraft.server.level.Ticket;
 import net.minecraft.server.level.TicketType;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(Ticket.class)
@@ -12,4 +13,6 @@ public interface TicketAccess {
     }
     @Invoker boolean invokeTimedOut(long currentTime);
     @Invoker void invokeSetCreatedTick(long time);
+
+    @Accessor <T> T getKey();
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/access/common/TicketManagerAccess.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/access/common/TicketManagerAccess.java
@@ -2,6 +2,7 @@ package io.github.opencubicchunks.cubicchunks.mixin.access.common;
 
 import net.minecraft.server.level.DistanceManager;
 import net.minecraft.server.level.Ticket;
+import net.minecraft.util.SortedArraySet;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
@@ -10,4 +11,7 @@ public interface TicketManagerAccess {
     @Invoker void invokeAddTicket(long chunkPosIn, Ticket<?> ticketIn);
 
     @Invoker void invokeUpdatePlayerTickets(int viewDistance);
+
+    @Invoker SortedArraySet<Ticket<?>> invokeGetTickets(long position);
+    @Invoker void invokeRemoveTicket(long pos, Ticket<?> ticket);
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/MixinMinecraftServer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/MixinMinecraftServer.java
@@ -68,10 +68,10 @@ public abstract class MixinMinecraftServer {
         int chunkDiameter = Coords.cubeToSection(radius, 0) * 2 + 1;
         int d = radius * 2 + 1;
         ((IServerChunkProvider) serverchunkprovider).addCubeRegionTicket(TicketType.START, spawnPosCube, radius + 1, Unit.INSTANCE);
-        serverchunkprovider.addRegionTicket(TicketType.START, spawnPosCube.asChunkPos(), Coords.cubeToSection(radius + 1, 0), Unit.INSTANCE);
+//        serverchunkprovider.addRegionTicket(TicketType.START, spawnPosCube.asChunkPos(), Coords.cubeToSection(radius + 1, 0), Unit.INSTANCE);
 
-        while (this.isRunning() && (serverchunkprovider.getTickingGenerated() < chunkDiameter * chunkDiameter
-            || ((IServerChunkProvider) serverchunkprovider).getTickingGeneratedCubes() < d * d * d)) {
+        while (this.isRunning() && (/*serverchunkprovider.getTickingGenerated() < chunkDiameter * chunkDiameter
+            ||*/ ((IServerChunkProvider) serverchunkprovider).getTickingGeneratedCubes() < d * d * d)) {
             // from CC
             this.nextTickTime = Util.getMillis() + 10L;
             this.waitUntilNextTick();

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/MixinServerChunkProvider.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/MixinServerChunkProvider.java
@@ -6,14 +6,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
-import com.mojang.datafixers.DataFixer;
 import com.mojang.datafixers.util.Either;
 import io.github.opencubicchunks.cubicchunks.CubicChunks;
 import io.github.opencubicchunks.cubicchunks.chunk.IBigCube;
@@ -41,20 +38,13 @@ import net.minecraft.server.level.DistanceManager;
 import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.TicketType;
-import net.minecraft.server.level.progress.ChunkProgressListener;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.NaturalSpawner;
 import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.chunk.ChunkStatus;
-import net.minecraft.world.level.entity.ChunkStatusUpdateListener;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureManager;
-import net.minecraft.world.level.storage.DimensionDataStorage;
 import net.minecraft.world.level.storage.LevelData;
-import net.minecraft.world.level.storage.LevelStorageSource;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -84,33 +74,6 @@ public abstract class MixinServerChunkProvider implements IServerChunkProvider, 
     @Shadow protected abstract boolean chunkAbsent(@Nullable ChunkHolder chunkHolderIn, int p_217224_2_);
 
     @Shadow public abstract int getLoadedChunksCount();
-
-    @Shadow @org.jetbrains.annotations.Nullable protected abstract ChunkHolder getVisibleChunkIfPresent(long pos);
-
-    @Inject(method = "<init>", at = @At("RETURN"))
-    private void onInit(ServerLevel serverLevel, LevelStorageSource.LevelStorageAccess levelStorageAccess, DataFixer dataFixer, StructureManager structureManager, Executor executor,
-                        ChunkGenerator chunkGenerator, int i, boolean bl, ChunkProgressListener chunkProgressListener, ChunkStatusUpdateListener chunkStatusUpdateListener,
-                        Supplier<DimensionDataStorage> supplier, CallbackInfo ci) {
-        ((IChunkManager) chunkMap).setServerChunkCache((ServerChunkCache) (Object) this);
-    }
-
-    @Override public ChunkHolder getChunkHolderForce(ChunkPos chunkPos, ChunkStatus requiredStatus) {
-        long pos = chunkPos.toLong();
-        ChunkHolder chunkHolder = this.getVisibleChunkIfPresent(pos);
-        int chunkLevel = 33 + ChunkStatus.getDistance(requiredStatus);
-        this.distanceManager.addTicket(TicketType.UNKNOWN, chunkPos, chunkLevel, chunkPos);
-        if (this.chunkAbsent(chunkHolder, chunkLevel)) {
-            ProfilerFiller profilerFiller = this.level.getProfiler();
-            profilerFiller.push("chunkLoad");
-            this.runChunkDistanceManagerUpdates();
-            chunkHolder = this.getVisibleChunkIfPresent(pos);
-            profilerFiller.pop();
-            if (this.chunkAbsent(chunkHolder, chunkLevel)) {
-                throw Util.pauseInIde(new IllegalStateException("No chunk holder after ticket has been added"));
-            }
-        }
-        return chunkHolder;
-    }
 
     @Override
     public <T> void addCubeRegionTicket(TicketType<T> type, CubePos pos, int distance, T value) {
@@ -261,17 +224,6 @@ public abstract class MixinServerChunkProvider implements IServerChunkProvider, 
             return;
         }
         this.clearCubeCache();
-    }
-
-    private boolean runChunkDistanceManagerUpdates() {
-        boolean flag = ((ITicketManager) this.distanceManager).runAllUpdatesForChunks(chunkMap);
-        boolean flag1 = ((ChunkManagerAccess) this.chunkMap).invokePromoteChunkMap();
-        if (!flag && !flag1) {
-            return false;
-        } else {
-            this.clearCubeCache();
-            return true;
-        }
     }
 
     // func_217235_l, runDistanceManagerUpdates

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkHolder.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkHolder.java
@@ -79,7 +79,6 @@ public abstract class MixinChunkHolder implements ICubeHolder {
     @Shadow private CompletableFuture<Void> pendingFullStateConfirmation;
     @Shadow @Final private LevelHeightAccessor levelHeightAccessor;
 
-    private ChunkHolder[] chunkHolders = null;
     @Shadow private boolean hasChangedSections;
 
     private CubePos cubePos; // set from ASM
@@ -312,39 +311,11 @@ public abstract class MixinChunkHolder implements ICubeHolder {
         }
     }
 
-    @Override
-    public void setChunkHolders(ChunkHolder[] chunkHolders) {
-        this.chunkHolders = chunkHolders;
-    }
-
-    @Override
-    public ChunkHolder[] getChunkHolders() {
-        return chunkHolders;
-    }
-
     // func_219276_a, getOrScheduleFuture
-    @Override public CompletableFuture<Either<IBigCube, ChunkHolder.ChunkLoadingFailure>> getOrScheduleCubeFuture(ChunkStatus targetStatus, ChunkMap chunkStorage) {
-        int i = targetStatus.getIndex();
-        CompletableFuture<Either<IBigCube, ChunkHolder.ChunkLoadingFailure>> completableFuture = futures.get(i);
-        if (completableFuture != null) {
-            Either<IBigCube, ChunkHolder.ChunkLoadingFailure> either = completableFuture.getNow(null);
-            if (either == null || either.left().isPresent()) {
-                return completableFuture;
-            }
-        }
-
-        if (getStatus(this.ticketLevel).isOrAfter(targetStatus)) {
-            CompletableFuture<Either<IBigCube, ChunkHolder.ChunkLoadingFailure>> completableFuture2 = ((IChunkManager) chunkStorage).scheduleCube((ChunkHolder) (Object) this,
-                targetStatus);
-            this.updateChunkToSave(completableFuture2, "schedule " + targetStatus);
-            this.futures.set(i, completableFuture2);
-            return completableFuture2;
-        } else {
-            return completableFuture == null ? UNLOADED_CUBE_FUTURE : completableFuture;
-        }
+    @Override public CompletableFuture<Either<IBigCube, ChunkHolder.ChunkLoadingFailure>> getOrScheduleCubeFuture(ChunkStatus chunkStatus, ChunkMap chunkManager) {
+        return getOrScheduleFuture(chunkStatus, chunkManager);
     }
 
-    @Override
     public void addCubeStageListener(ChunkStatus status, BiConsumer<Either<IBigCube, ChunkHolder.ChunkLoadingFailure>, Throwable> consumer, ChunkMap chunkManager) {
         CompletableFuture<Either<IBigCube, ChunkHolder.ChunkLoadingFailure>> future = getOrScheduleFuture(status, chunkManager);
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkStatus.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkStatus.java
@@ -15,7 +15,9 @@ import io.github.opencubicchunks.cubicchunks.chunk.NoiseAndSurfaceBuilderHelper;
 import io.github.opencubicchunks.cubicchunks.chunk.biome.ColumnBiomeContainer;
 import io.github.opencubicchunks.cubicchunks.chunk.cube.CubePrimer;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
+import io.github.opencubicchunks.cubicchunks.mixin.access.common.ChunkManagerAccess;
 import io.github.opencubicchunks.cubicchunks.mixin.access.common.StructureFeatureManagerAccess;
+import io.github.opencubicchunks.cubicchunks.mixin.access.common.ThreadedLevelLightEngineAccess;
 import io.github.opencubicchunks.cubicchunks.server.CubicLevelHeightAccessor;
 import io.github.opencubicchunks.cubicchunks.world.CubeWorldGenRegion;
 import io.github.opencubicchunks.cubicchunks.world.server.IServerWorldLightManager;
@@ -23,6 +25,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ThreadedLevelLightEngine;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.StructureFeatureManager;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ChunkGenerator;
@@ -394,6 +397,10 @@ public class MixinChunkStatus {
         }
 
         if (!(chunk instanceof CubePrimer)) {
+            ChunkPos pos = chunk.getPos();
+            ((ThreadedLevelLightEngineAccess) lightManager).invokeAddTask(pos.x, pos.z, ThreadedLevelLightEngine.TaskType.PRE_UPDATE, () -> {
+                ((ChunkManagerAccess) ((ThreadedLevelLightEngineAccess) lightManager).getChunkMap()).invokeReleaseLightTicket(pos);
+            });
             if (!chunk.getStatus().isOrAfter(status)) {
                 ((ProtoChunk) chunk).setStatus(status);
             }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/ticket/MixinTicketManager.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/ticket/MixinTicketManager.java
@@ -20,7 +20,6 @@ import io.github.opencubicchunks.cubicchunks.chunk.ticket.PlayerCubeTicketTracke
 import io.github.opencubicchunks.cubicchunks.chunk.ticket.PlayerCubeTracker;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
 import io.github.opencubicchunks.cubicchunks.mixin.access.common.ChunkHolderAccess;
-import io.github.opencubicchunks.cubicchunks.mixin.access.common.ChunkManagerAccess;
 import io.github.opencubicchunks.cubicchunks.mixin.access.common.TicketAccess;
 import io.github.opencubicchunks.cubicchunks.utils.Coords;
 import io.github.opencubicchunks.cubicchunks.utils.MathUtil;
@@ -34,14 +33,12 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ChunkMap;
-import net.minecraft.server.level.ChunkTaskPriorityQueueSorter;
 import net.minecraft.server.level.DistanceManager;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.Ticket;
 import net.minecraft.server.level.TicketType;
 import net.minecraft.util.SortedArraySet;
 import net.minecraft.util.thread.ProcessorHandle;
-import net.minecraft.world.level.chunk.LevelChunk;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -52,6 +49,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(DistanceManager.class)
 public abstract class MixinTicketManager implements ITicketManager, IVerticalView {
+
+    @Final @Shadow private Executor mainThreadExecutor;
+    @Shadow private long ticketTickCounter;
 
     private final Long2ObjectOpenHashMap<SortedArraySet<Ticket<?>>> cubeTickets = new Long2ObjectOpenHashMap<>();
     private final Long2ObjectMap<ObjectSet<ServerPlayer>> playersPerCube = new Long2ObjectOpenHashMap<>();
@@ -68,27 +68,9 @@ public abstract class MixinTicketManager implements ITicketManager, IVerticalVie
 
     private boolean isCubic;
 
-    @Shadow @Final private DistanceManager.FixedPlayerDistanceChunkTracker naturalSpawnChunkCounter;
-
-    @Shadow @Final private DistanceManager.PlayerTicketTracker playerTicketManager;
-
-    @Shadow @Final private DistanceManager.ChunkTicketTracker ticketTracker;
-
-    @Shadow @Final private Set<ChunkHolder> chunksToUpdateFutures;
-
-    @Shadow @Final private LongSet ticketsToRelease;
-
-    @Shadow @Final private ProcessorHandle<ChunkTaskPriorityQueueSorter.Release> ticketThrottlerReleaser;
-
-    @Final @Shadow private Executor mainThreadExecutor;
-
-    @Shadow private long ticketTickCounter;
-
     @Shadow private static int getTicketLevelAt(SortedArraySet<Ticket<?>> p_229844_0_) {
         throw new Error("Mixin did not apply correctly");
     }
-
-    @Shadow protected abstract SortedArraySet<Ticket<?>> getTickets(long position);
 
     @Inject(method = "<init>", at = @At("RETURN"))
     public void init(Executor executor, Executor executor2, CallbackInfo ci) {
@@ -128,45 +110,6 @@ public abstract class MixinTicketManager implements ITicketManager, IVerticalVie
     }
 
     //BEGIN INJECT
-
-    @Override public boolean runAllUpdatesForChunks(ChunkMap chunkMap) {
-        this.naturalSpawnChunkCounter.runAllUpdates();
-        this.playerTicketManager.runAllUpdates();
-        int i = Integer.MAX_VALUE - this.ticketTracker.runDistanceUpdates(Integer.MAX_VALUE);
-        boolean bl = i != 0;
-
-        if (!this.chunksToUpdateFutures.isEmpty()) {
-            this.chunksToUpdateFutures.forEach((chunkHolder) -> ((ChunkHolderAccess) chunkHolder).invokeUpdateFutures(chunkMap, this.mainThreadExecutor));
-            this.chunksToUpdateFutures.clear();
-            return true;
-        } else {
-            if (!this.ticketsToRelease.isEmpty()) {
-                LongIterator longIterator = this.ticketsToRelease.iterator();
-
-                while (longIterator.hasNext()) {
-                    long l = longIterator.nextLong();
-                    if (this.getTickets(l).stream().anyMatch((ticket) -> ticket.getType() == TicketType.PLAYER)) {
-                        ChunkHolder chunkHolder = ((ChunkManagerAccess) chunkMap).invokeGetUpdatingChunkIfPresent(l);
-                        if (chunkHolder == null) {
-                            throw new IllegalStateException();
-                        }
-
-                        CompletableFuture<Either<LevelChunk, ChunkHolder.ChunkLoadingFailure>> completableFuture = chunkHolder.getEntityTickingChunkFuture();
-                        completableFuture.thenAccept((either) -> {
-                            this.mainThreadExecutor.execute(() -> {
-                                this.ticketThrottlerReleaser.tell(ChunkTaskPriorityQueueSorter.release(() -> {
-                                }, l, false));
-                            });
-                        });
-                    }
-                }
-
-                this.ticketsToRelease.clear();
-            }
-
-            return bl;
-        }
-    }
 
     @Inject(method = "runAllUpdates", at = @At("RETURN"), cancellable = true)
     public void processUpdates(ChunkMap chunkManager, CallbackInfoReturnable<Boolean> callbackInfoReturnable) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/lighting/MixinThreadedLevelLightEngine.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/lighting/MixinThreadedLevelLightEngine.java
@@ -135,11 +135,11 @@ public abstract class MixinThreadedLevelLightEngine extends MixinLevelLightEngin
                 super.doSkyLightForCube(icube);
             }
 
-            ((IChunkManager) this.chunkMap).releaseLightTicket(cubePos);
         }, () -> "lightCube " + cubePos + " " + flagIn));
         return CompletableFuture.supplyAsync(() -> {
             icube.setCubeLight(true);
             super.retainData(cubePos, false);
+            ((IChunkManager) this.chunkMap).releaseLightTicket(cubePos);
             return icube;
         }, (runnable) -> {
             this.addTask(cubePos.getX(), cubePos.getY(), cubePos.getZ(), ThreadedLevelLightEngine.TaskType.POST_UPDATE, runnable);

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/lighting/MixinThreadedLevelLightEngine.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/lighting/MixinThreadedLevelLightEngine.java
@@ -21,6 +21,7 @@ import net.minecraft.core.SectionPos;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ThreadedLevelLightEngine;
 import net.minecraft.util.thread.ProcessorHandle;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.chunk.DataLayer;
 import net.minecraft.world.level.chunk.LevelChunkSection;
@@ -151,6 +152,13 @@ public abstract class MixinThreadedLevelLightEngine extends MixinLevelLightEngin
         this.addTask(SectionPos.blockToSectionCoord(x), SectionPos.blockToSectionCoord(z), ThreadedLevelLightEngine.TaskType.POST_UPDATE, Util.name(() -> {
             super.checkSkyLightColumn(chunk, x, z, oldHeight, newHeight);
         }, () -> "checkSkyLightColumn " + x + " " + z));
+    }
+
+    @Inject(method = "updateChunkStatus", at = @At("HEAD"), cancellable = true)
+    private void cancelUpdateChunkStatus(ChunkPos pos, CallbackInfo ci) {
+        if (((CubicLevelHeightAccessor) this.levelHeightAccessor).isCubic()) {
+            ci.cancel();
+        }
     }
 
     /**

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/client/MixinLevelRenderer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/client/MixinLevelRenderer.java
@@ -10,7 +10,7 @@ import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.math.Matrix4f;
 import com.mojang.math.Vector3f;
-import io.github.opencubicchunks.cubicchunks.chunk.ICubeHolder;
+import io.github.opencubicchunks.cubicchunks.chunk.IBigCube;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
 import io.github.opencubicchunks.cubicchunks.client.CubicWorldLoadScreen;
 import io.github.opencubicchunks.cubicchunks.utils.Coords;
@@ -63,8 +63,8 @@ public class MixinLevelRenderer {
             CubicWorldLoadScreen.class, null, "STATUS_COLORS" // TODO: intermediary name
         );
 
-        int renderRadius = 25;
-        int chunkRenderRadius = 100; //renderRadius * IBigCube.DIAMETER_IN_SECTIONS;
+        int renderRadius = 5;
+        int chunkRenderRadius = renderRadius * IBigCube.DIAMETER_IN_SECTIONS;
         Long2ObjectLinkedOpenHashMap<ChunkHolder> loadedColumns = getField(ChunkMap.class, levelAccessor.getChunkSource().chunkMap, "updatingChunkMap");
 
         Object[] data = getField(Long2ObjectLinkedOpenHashMap.class, loadedColumns, "value");
@@ -84,7 +84,7 @@ public class MixinLevelRenderer {
             if (holder == null) {
                 continue;
             }
-            ChunkStatus status = ICubeHolder.getCubeStatusFromLevel(holder.getTicketLevel());
+            ChunkStatus status = holder.getLastAvailableStatus();
 
             int color = colors.getOrDefault(status, 0);
 
@@ -121,7 +121,7 @@ public class MixinLevelRenderer {
             if (holder == null) {
                 continue;
             }
-            ChunkStatus status = ICubeHolder.getCubeStatusFromLevel(holder.getTicketLevel());
+            ChunkStatus status = holder.getLastAvailableStatus();
 
             int color = colors.getOrDefault(status, 0);
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/client/MixinLevelRenderer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/client/MixinLevelRenderer.java
@@ -64,8 +64,8 @@ public class MixinLevelRenderer {
             LevelLoadingScreen.class, null, "COLORS" // TODO: intermediary name
         );
 
-        int renderRadius = 5;
-        int chunkRenderRadius = renderRadius * IBigCube.DIAMETER_IN_SECTIONS;
+        int renderRadius = 1;
+        int chunkRenderRadius = 100; //renderRadius * IBigCube.DIAMETER_IN_SECTIONS;
         Long2ObjectLinkedOpenHashMap<ChunkHolder> loadedColumns = getField(ChunkMap.class, levelAccessor.getChunkSource().chunkMap, "updatingChunkMap");
 
         Object[] data = getField(Long2ObjectLinkedOpenHashMap.class, loadedColumns, "value");

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/client/MixinLevelRenderer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/client/MixinLevelRenderer.java
@@ -10,15 +10,14 @@ import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.math.Matrix4f;
 import com.mojang.math.Vector3f;
-import io.github.opencubicchunks.cubicchunks.chunk.IBigCube;
 import io.github.opencubicchunks.cubicchunks.chunk.ICubeHolder;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
+import io.github.opencubicchunks.cubicchunks.client.CubicWorldLoadScreen;
 import io.github.opencubicchunks.cubicchunks.utils.Coords;
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.screens.LevelLoadingScreen;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.LightTexture;
@@ -61,10 +60,10 @@ public class MixinLevelRenderer {
         bufferBuilder.begin(VertexFormat.Mode.TRIANGLE_STRIP, DefaultVertexFormat.POSITION_COLOR);
 
         Object2IntMap<ChunkStatus> colors = getField(
-            LevelLoadingScreen.class, null, "COLORS" // TODO: intermediary name
+            CubicWorldLoadScreen.class, null, "STATUS_COLORS" // TODO: intermediary name
         );
 
-        int renderRadius = 1;
+        int renderRadius = 25;
         int chunkRenderRadius = 100; //renderRadius * IBigCube.DIAMETER_IN_SECTIONS;
         Long2ObjectLinkedOpenHashMap<ChunkHolder> loadedColumns = getField(ChunkMap.class, levelAccessor.getChunkSource().chunkMap, "updatingChunkMap");
 
@@ -131,12 +130,16 @@ public class MixinLevelRenderer {
             int xPos = Coords.cubeToMinBlock(cubeX);
             int yPos = Coords.cubeToMinBlock(cubeY);
             int zPos = Coords.cubeToMinBlock(cubeZ);
-            LevelRenderer.addChainedFilledBoxVertices(bufferBuilder, xPos + 4.25F - cameraX, yPos - 4.25F - cameraY, zPos + 4.25F - cameraZ,
-                xPos + 11.75F - cameraX, yPos + 4.25F - cameraY, zPos + 11.75F - cameraZ, vector3f.x(), vector3f.y(), vector3f.z(), 1.0F);
+            drawBox(bufferBuilder, cameraX, cameraY, cameraZ, xPos + 16, yPos + 16, zPos + 16, 4, vector3f);
         }
 
         tesselator.end();
         RenderSystem.enableTexture();
+    }
+
+    private void drawBox(BufferBuilder bufferBuilder, double cameraX, double cameraY, double cameraZ, float x, float y, float z, float radius, Vector3f color) {
+        LevelRenderer.addChainedFilledBoxVertices(bufferBuilder, x - radius - cameraX, y - radius - cameraY, z - radius - cameraZ,
+            x + radius - cameraX, y + radius - cameraY, z + radius - cameraZ, color.x(), color.y(), color.z(), 1.0F);
     }
 
     private static <T> T getField(Class<?> cl, Object obj, String name) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinDistanceManager.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinDistanceManager.java
@@ -1,5 +1,6 @@
 package io.github.opencubicchunks.cubicchunks.mixin.debug.common;
 
+import io.github.opencubicchunks.cubicchunks.chunk.graph.CCTicketType;
 import net.minecraft.server.level.DistanceManager;
 import net.minecraft.server.level.Ticket;
 import net.minecraft.server.level.TicketType;
@@ -17,7 +18,7 @@ public class MixinDistanceManager {
         if (!DEBUG_LOAD_ORDER_ENABLED) {
             return;
         }
-        if (ticket.getType() == TicketType.PLAYER) {
+        if (ticket.getType() == TicketType.PLAYER || ticket.getType() == CCTicketType.CCPLAYER) {
             ci.cancel();
         }
     }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinMinecraftServer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinMinecraftServer.java
@@ -90,11 +90,11 @@ public abstract class MixinMinecraftServer {
             this.waitUntilNextTick();
         }
 
-        try {
-            Thread.sleep(10000);
-        } catch (InterruptedException e) {
-            int ignored = 0;
-        }
+//        try {
+//            Thread.sleep(10000);
+//        } catch (InterruptedException e) {
+//            int ignored = 0;
+//        }
 
         this.nextTickTime = Util.getMillis() + 10L;
         this.waitUntilNextTick();

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/server/IServerChunkProvider.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/server/IServerChunkProvider.java
@@ -9,6 +9,8 @@ import io.github.opencubicchunks.cubicchunks.chunk.cube.BigCube;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.TicketType;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.ChunkStatus;
 
 public interface IServerChunkProvider extends ICubeProvider {
     <T> void addCubeRegionTicket(TicketType<T> type, CubePos pos, int distance, T value);
@@ -17,6 +19,7 @@ public interface IServerChunkProvider extends ICubeProvider {
 
     void forceCube(CubePos pos, boolean add);
 
+    CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> getColumnFutureForCube(CubePos cubePos, int chunkX, int chunkZ, ChunkStatus leastStatus, boolean create);
     boolean isEntityTickingCube(CubePos pos);
 
     boolean checkCubeFuture(long cubePosLong, Function<ChunkHolder, CompletableFuture<Either<BigCube, ChunkHolder.ChunkLoadingFailure>>> futureFunction);

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/server/IServerChunkProvider.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/server/IServerChunkProvider.java
@@ -9,12 +9,8 @@ import io.github.opencubicchunks.cubicchunks.chunk.cube.BigCube;
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.TicketType;
-import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.chunk.ChunkStatus;
 
 public interface IServerChunkProvider extends ICubeProvider {
-    ChunkHolder getChunkHolderForce(ChunkPos chunkPos, ChunkStatus requiredStatus);
-
     <T> void addCubeRegionTicket(TicketType<T> type, CubePos pos, int distance, T value);
 
     int getTickingGeneratedCubes();

--- a/src/main/resources/cubicchunks.mixins.access.json
+++ b/src/main/resources/cubicchunks.mixins.access.json
@@ -32,7 +32,8 @@
         "common.TicketAccess",
         "common.TicketManagerAccess",
         "common.TicketTypeAccess",
-        "common.VerticalAnchorAccess"
+        "common.VerticalAnchorAccess",
+        "common.ThreadedLevelLightEngineAccess"
     ],
     "client": [
         "client.ChunkRenderDispatcherAccess",


### PR DESCRIPTION
Please test to make sure it's correct, though it looks good in my limited testing

Reverts the old load order which was incorrect

The idea of this load order concept is:

- On cube requested, request all of its columns with a `CCColumn` ticket type
- Chain the cube future onto the chained column futures on the correct executors to avoid deadlock
- On unload, remove the `CCColumn` ticket

Also fixed in this PR is:
- https://bugs.mojang.com/browse/MC-224894
- Status debug renderer being wrong