### PR TITLE
Lighting related Load Order fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,7 @@ minecraft {
             "-Dcubicchunks.debug.window=false",
             "-Dcubicchunks.debug.statusrenderer=false",
             "-Dcubicchunks.debug.biomes=false",
+            "-ea"
     ]
 
     runConfigs {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/IBigCube.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/IBigCube.java
@@ -90,6 +90,6 @@ public interface IBigCube extends BlockGetter, ChunkAccess, FeatureAccess {
     default void loadHeightmapSection(SurfaceTrackerSection section, int localSectionX, int localSectionZZ) {
     }
 
-    default void loadLightHeightmapSection(LightSurfaceTrackerSection section, int localSectionX, int localSectionZZ) {
+    default void setLightHeightmapSection(LightSurfaceTrackerSection section, int localSectionX, int localSectionZZ) {
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/cube/BigCube.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/cube/BigCube.java
@@ -236,7 +236,7 @@ public class BigCube implements ChunkAccess, IBigCube, CubicLevelHeightAccessor 
         this.dirty = true;
     }
 
-    @Override public void loadLightHeightmapSection(LightSurfaceTrackerSection section, int localSectionX, int localSectionZ) {
+    @Override public void setLightHeightmapSection(LightSurfaceTrackerSection section, int localSectionX, int localSectionZ) {
         int idx = localSectionX + localSectionZ * DIAMETER_IN_SECTIONS;
 
         this.lightHeightmaps[idx] = section;
@@ -1003,6 +1003,7 @@ public class BigCube implements ChunkAccess, IBigCube, CubicLevelHeightAccessor 
         ChunkPos pos = this.cubePos.asChunkPos();
         for (int x = 0; x < IBigCube.DIAMETER_IN_SECTIONS; x++) {
             for (int z = 0; z < IBigCube.DIAMETER_IN_SECTIONS; z++) {
+
                 // TODO force-loading columns is questionable, until we get load order
                 LevelChunk chunk = this.level.getChunk(pos.x + x, pos.z + z);
                 ((CubeMapGetter) chunk).getCubeMap().markLoaded(this.cubePos.getY());
@@ -1011,6 +1012,7 @@ public class BigCube implements ChunkAccess, IBigCube, CubicLevelHeightAccessor 
                     SurfaceTrackerWrapper tracker = (SurfaceTrackerWrapper) heightmap;
                     tracker.loadCube(this);
                 }
+
                 if (!this.level.isClientSide) {
                     // TODO probably don't want to do this if the cube was already loaded as a CubePrimer
                     ((LightHeightmapGetter) chunk).getServerLightHeightmap().loadCube(this);

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/cube/CubePrimer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/cube/CubePrimer.java
@@ -190,7 +190,7 @@ public class CubePrimer extends ProtoChunk implements IBigCube, CubicLevelHeight
     public void setCubeStatus(ChunkStatus newStatus) {
         this.status = newStatus;
 
-        if (this.status == ChunkStatus.LIGHT) {
+        if (this.status == ChunkStatus.FEATURES) {
             ChunkSource chunkSource = getChunkSource();
 
             for (int dx = 0; dx < IBigCube.DIAMETER_IN_SECTIONS; dx++) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/heightmap/LightSurfaceTrackerSection.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/heightmap/LightSurfaceTrackerSection.java
@@ -145,7 +145,7 @@ public class LightSurfaceTrackerSection extends SurfaceTrackerSection {
         }
         if (this.scale == 0) {
             // TODO merge loadHeightmapSection and loadLightHeightmapSection, and just use instanceof checks in the implementation to figure out if it's a light heightmap?
-            newCube.loadLightHeightmapSection(this, sectionX, sectionZ);
+            newCube.setLightHeightmapSection(this, sectionX, sectionZ);
             return;
         }
         int idx = indexOfRawHeightNode(newCube.getCubePos().getY(), scale, scaledY);

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunk.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunk.java
@@ -81,15 +81,6 @@ public abstract class MixinChunk implements ChunkAccess, LightHeightmapGetter, C
         if (!isCubic) {
             throw new UnsupportedOperationException("Attempted to get light heightmap on a non-cubic chunk");
         }
-        // FIXME remove debug
-        if (lightHeightmap == null) {
-            System.out.println("late creation of light heightmap in MixinChunk");
-            if (level.isClientSide) {
-                lightHeightmap = new ClientLightSurfaceTracker(this);
-            } else {
-                lightHeightmap = new LightSurfaceTrackerWrapper(this);
-            }
-        }
         return lightHeightmap;
     }
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinProtoChunk.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinProtoChunk.java
@@ -48,11 +48,6 @@ public abstract class MixinProtoChunk implements LightHeightmapGetter, LevelHeig
         if (!isCubic) {
             throw new UnsupportedOperationException("Attempted to get light heightmap on a non-cubic chunk");
         }
-        // FIXME remove debug
-        if (lightHeightmap == null) {
-            System.out.println("late creation of light heightmap in MixinProtoChunk");
-            lightHeightmap = new LightSurfaceTrackerWrapper((ChunkAccess) this);
-        }
         return lightHeightmap;
     }
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/lighting/MixinSkyLightEngine.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/lighting/MixinSkyLightEngine.java
@@ -127,19 +127,15 @@ public abstract class MixinSkyLightEngine extends MixinLayerLightEngine<SkyLight
 
         BlockGetter chunk = this.chunkSource.getChunkForLighting(SectionPos.blockToSectionCoord(pos.getX()), SectionPos.blockToSectionCoord(pos.getZ()));
 
-        // the load order guarantees the chunk being present
-        assert(chunk != null);
-
         if (chunk == null) {
-            System.out.println("onGetComputedLevel chunk was null " + (((Level) this.chunkSource.getLevel()).isClientSide ? "client" : "server"));
+            // ToDo Known bug: Cubes may be sent to the client ahead of their chunks. This is not fatal.
+            // see MixinSkyLightSectionStorage.onGetLightValue(...)
+            System.out.println("getComputedLevel: Missing chunk for lighting.");
             return;
         }
 
         Heightmap heightmap = ((LightHeightmapGetter) chunk).getLightHeightmap();
-        if (heightmap == null) {
-            System.out.println("onGetComputedLevel heightmap was null " + (((Level) this.chunkSource.getLevel()).isClientSide ? "client" : "server"));
-            return;
-        }
+
         int height = heightmap.getFirstAvailable(pos.getX() & 0xF, pos.getZ() & 0xF);
         if (height <= pos.getY()) {
             cir.setReturnValue(0);

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/lighting/MixinSkyLightEngine.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/lighting/MixinSkyLightEngine.java
@@ -125,12 +125,16 @@ public abstract class MixinSkyLightEngine extends MixinLayerLightEngine<SkyLight
             return;
         }
 
-        // TODO chunk can be null until load order is fixed
         BlockGetter chunk = this.chunkSource.getChunkForLighting(SectionPos.blockToSectionCoord(pos.getX()), SectionPos.blockToSectionCoord(pos.getZ()));
+
+        // the load order guarantees the chunk being present
+        assert(chunk != null);
+
         if (chunk == null) {
             System.out.println("onGetComputedLevel chunk was null " + (((Level) this.chunkSource.getLevel()).isClientSide ? "client" : "server"));
             return;
         }
+
         Heightmap heightmap = ((LightHeightmapGetter) chunk).getLightHeightmap();
         if (heightmap == null) {
             System.out.println("onGetComputedLevel heightmap was null " + (((Level) this.chunkSource.getLevel()).isClientSide ? "client" : "server"));
@@ -150,17 +154,18 @@ public abstract class MixinSkyLightEngine extends MixinLayerLightEngine<SkyLight
         int maxY = cubePos.maxCubeY();
         for (int sectionX = 0; sectionX < IBigCube.DIAMETER_IN_SECTIONS; sectionX++) {
             for (int sectionZ = 0; sectionZ < IBigCube.DIAMETER_IN_SECTIONS; sectionZ++) {
-                // TODO chunk can be null until load order is fixed
+
                 BlockGetter chunk = this.chunkSource.getChunkForLighting(chunkPos.x + sectionX, chunkPos.z + sectionZ);
-                if (chunk == null) {
-                    System.out.println("null chunk in MixinSkyLightEngine.doSkyLightForCube");
-                    return;
-                }
+
+                // the load order guarantees the chunk being present
+                assert(chunk != null);
+
                 CubeMap cubeMap = ((CubeMapGetter) chunk).getCubeMap();
                 if (!cubeMap.isLoaded(cubePos.getY())) {
                     // This is probably only happening because we don't have load order fixed yet
                     System.out.println(cube.getCubePos() + " : Cube not in cubemap during sky lighting");
                 }
+
                 Heightmap heightmap = ((LightHeightmapGetter) chunk).getLightHeightmap();
                 if (heightmap == null) {
                     System.out.println("heightmap null");

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/lighting/MixinSkyLightSectionStorage.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/lighting/MixinSkyLightSectionStorage.java
@@ -51,14 +51,11 @@ public abstract class MixinSkyLightSectionStorage extends LayerLightSectionStora
         int y = BlockPos.getY(blockPos);
         int z = BlockPos.getZ(blockPos);
         if (dataLayer == null) {
+
             BlockGetter chunk = ((LayerLightSectionStorageAccess) this).getChunkSource().getChunkForLighting(Coords.blockToSection(x), Coords.blockToSection(z));
-            if (chunk == null) {
-                // TODO This currently gets called a lot; not sure if it's due to broken load order or this method being called before the lighting stage or in unloaded chunks/cubes
-//                System.out.println("Null chunk (" + Coords.blockToSection(x) + ", " + Coords.blockToSection(z) + ") in MixinSkyLightSectionStorage.onGetLightValue "
-//                        + ((SectionLightStorageAccess) this).getChunkSource().getLevel());
-                cir.setReturnValue(0);
-                return;
-            }
+
+            // load order guarantees the chunk being present
+            assert(chunk != null);
 
             //TODO: Optimize
             BlockGetter cube = ((ICubeLightProvider) ((LayerLightSectionStorageAccess) this).getChunkSource()).getCubeForLighting(

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/lighting/MixinSkyLightSectionStorage.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/lighting/MixinSkyLightSectionStorage.java
@@ -10,6 +10,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.LightLayer;
+import net.minecraft.world.level.chunk.ChunkSource;
 import net.minecraft.world.level.chunk.ChunkStatus;
 import net.minecraft.world.level.chunk.DataLayer;
 import net.minecraft.world.level.chunk.LightChunkGetter;
@@ -54,8 +55,12 @@ public abstract class MixinSkyLightSectionStorage extends LayerLightSectionStora
 
             BlockGetter chunk = ((LayerLightSectionStorageAccess) this).getChunkSource().getChunkForLighting(Coords.blockToSection(x), Coords.blockToSection(z));
 
-            // load order guarantees the chunk being present
-            assert(chunk != null);
+            if (chunk == null) {
+                // ToDo Known bug: Cubes may be sent to the client ahead of their chunks. This is not fatal.
+                // see MixinSkyLightEngine.onGetComputedLevel(...)
+                System.out.println("getLightValue: Missing chunk for lighting.");
+                return;
+            }
 
             //TODO: Optimize
             BlockGetter cube = ((ICubeLightProvider) ((LayerLightSectionStorageAccess) this).getChunkSource()).getCubeForLighting(


### PR DESCRIPTION
This is my attempt at fixing load order related bugs in lighting. I could not find any instances of subterranean skylight on the server. I found one case of client side skylight underground. This is likely due to cubes and chunks being set in the wrong order. This should be fixed, but it is not game breaking as of right now. There were no visible surface lighting errors.