### PR TITLE
fix loading old worlds when the default save format isn't anvil3d

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/core/world/WorldSavedCubicChunksData.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/core/world/WorldSavedCubicChunksData.java
@@ -65,7 +65,9 @@ public class WorldSavedCubicChunksData extends WorldSavedData {
         if(nbt.hasKey("storageFormat"))
             storageFormat = new ResourceLocation(nbt.getString("storageFormat"));
         else
-            storageFormat = StorageFormatProviderBase.defaultStorageFormatProviderName(CubicChunksConfig.storageFormat);
+            //if no storage format is set, we should assume that this world was created before the custom storage API. therefore, it
+            // must be using anvil3d.
+            storageFormat = StorageFormatProviderBase.DEFAULT;
     }
 
     @Override


### PR DESCRIPTION
otherwise, the world would be switched to whatever the default format is and existing anvil3d data discarded. 