### PR TITLE
Correctly chain future dependencies in noise status

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/cube/CubePrimer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/cube/CubePrimer.java
@@ -11,7 +11,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -121,7 +120,7 @@ public class CubePrimer extends ProtoChunk implements IBigCube, CubicLevelHeight
         this.carvingMasks = new Object2ObjectArrayMap<>();
 
         this.structureStarts = Maps.newHashMap();
-        this.structuresRefences = new ConcurrentHashMap<>(); // Maps.newHashMap(); //TODO: This should NOT be a ConcurrentHashMap
+        this.structuresRefences = Maps.newHashMap();
 
         this.cubePos = cubePosIn;
         this.levelHeightAccessor = levelHeightAccessor;
@@ -326,12 +325,7 @@ public class CubePrimer extends ProtoChunk implements IBigCube, CubicLevelHeight
         this.addCubeLightPosition(unpackToWorld(packedPosition, yOffset, this.cubePos));
     }
 
-    /**
-     * Due to splitting the same cube into several threads in MixinChunkStatus,
-     * we have to make this method synchronized to ensure we aren't letting null values slip by.
-     */
-    //TODO: DO NOT Make THE SAME Cube's generation multithreaded in ChunkStatus Noise.
-    public synchronized void addCubeLightPosition(BlockPos lightPos) {
+    public void addCubeLightPosition(BlockPos lightPos) {
         this.lightPositions.add(lightPos.immutable());
     }
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkStatus.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkStatus.java
@@ -216,7 +216,6 @@ public class MixinChunkStatus {
 
             CubePrimer cubeAbove = new CubePrimer(CubePos.of(cubePos.getX(), cubeY + 1,
                 cubePos.getZ()), UpgradeData.EMPTY, cubeWorldGenRegion);
-            NoiseAndSurfaceBuilderHelper cubeAccessWrapper = new NoiseAndSurfaceBuilderHelper((IBigCube) chunk, cubeAbove);
 
             CompletableFuture<ChunkAccess> chainedNoiseFutures = null;
 
@@ -229,6 +228,7 @@ public class MixinChunkStatus {
 
                     ChunkPos pos = chunk.getPos();
 
+                    NoiseAndSurfaceBuilderHelper cubeAccessWrapper = new NoiseAndSurfaceBuilderHelper((IBigCube) chunk, cubeAbove);
                     cubeAccessWrapper.moveColumn(columnX, columnZ);
 
                     if (chainedNoiseFutures == null) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkStatus.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkStatus.java
@@ -213,10 +213,12 @@ public class MixinChunkStatus {
 
             CubePos cubePos = ((IBigCube) chunk).getCubePos();
             int cubeY = cubePos.getY();
+
             CubePrimer cubeAbove = new CubePrimer(CubePos.of(cubePos.getX(), cubeY + 1,
                 cubePos.getZ()), UpgradeData.EMPTY, cubeWorldGenRegion);
+            NoiseAndSurfaceBuilderHelper cubeAccessWrapper = new NoiseAndSurfaceBuilderHelper((IBigCube) chunk, cubeAbove);
 
-            CompletableFuture<ChunkAccess> completableFuture = null;
+            CompletableFuture<ChunkAccess> chainedNoiseFutures = null;
 
             for (int columnX = 0; columnX < IBigCube.DIAMETER_IN_SECTIONS; columnX++) {
                 for (int columnZ = 0; columnZ < IBigCube.DIAMETER_IN_SECTIONS; columnZ++) {
@@ -227,45 +229,47 @@ public class MixinChunkStatus {
 
                     ChunkPos pos = chunk.getPos();
 
-                    NoiseAndSurfaceBuilderHelper cubeAccessWrapper = new NoiseAndSurfaceBuilderHelper((IBigCube) chunk, cubeAbove);
                     cubeAccessWrapper.moveColumn(columnX, columnZ);
-                    CompletableFuture<ChunkAccess> chunkAccessCompletableFuture =
-                        generator.fillFromNoise(executor, world.structureFeatureManager().forWorldGenRegion(cubeWorldGenRegion), cubeAccessWrapper).thenApply(chunkAccess -> {
-                            cubeAccessWrapper.applySections();
 
-
-                            // Exit early and don't waste time on empty sections.
-                            if (areSectionsEmpty(cubeY, pos, ((NoiseAndSurfaceBuilderHelper) chunkAccess).getDelegateByIndex(0))) {
-                                return chunkAccess;
-                            }
-
-                            generator.buildSurfaceAndBedrock(cubeWorldGenRegion, chunkAccess);
-
-                            // Carvers
-                            generator.applyCarvers(world.getSeed(), world.getBiomeManager(), cubeAccessWrapper, GenerationStep.Carving.AIR);
-                            generator.applyCarvers(world.getSeed(), world.getBiomeManager(), cubeAccessWrapper, GenerationStep.Carving.LIQUID);
-                            return chunkAccess;
-                        });
-                    if (completableFuture == null) {
-                        completableFuture = chunkAccessCompletableFuture;
+                    if (chainedNoiseFutures == null) {
+                        chainedNoiseFutures = getNoiseSurfaceCarverFuture(executor, world, generator, cubeWorldGenRegion, cubeY, pos, cubeAccessWrapper);
                     } else {
-                        completableFuture = completableFuture.thenCombine(chunkAccessCompletableFuture, (chunk1, chunk2) -> chunk1);
+                        // Wait for first completion stage to complete before getting the next future, as it calls supplyAsync internally
+                        chainedNoiseFutures =
+                            chainedNoiseFutures.thenCompose(futureIn -> getNoiseSurfaceCarverFuture(executor, world, generator, cubeWorldGenRegion, cubeY, pos, cubeAccessWrapper));
                     }
                 }
             }
-            assert completableFuture != null;
-            ci.setReturnValue(completableFuture.thenApply(chunkAccess2 -> {
+            assert chainedNoiseFutures != null;
+            ci.setReturnValue(chainedNoiseFutures.thenApply(ignored -> {
                 if (chunk instanceof CubePrimer) {
                     ((CubePrimer) chunk).setCubeStatus(status);
                 }
-
-//                System.out.println("Total time taken for cycle: " + totalTimeForCycle  + "ms. Skipped Carvers: " + skipped);
 
                 return Either.left(chunk);
             }));
         } else {
             ci.setReturnValue(CompletableFuture.completedFuture(Either.left(chunk)));
         }
+    }
+
+    private static CompletableFuture<ChunkAccess> getNoiseSurfaceCarverFuture(Executor executor, ServerLevel world, ChunkGenerator generator, CubeWorldGenRegion cubeWorldGenRegion,
+                                                                              int cubeY, ChunkPos pos, NoiseAndSurfaceBuilderHelper cubeAccessWrapper) {
+        return generator.fillFromNoise(executor, world.structureFeatureManager().forWorldGenRegion(cubeWorldGenRegion), cubeAccessWrapper).thenApply(chunkAccess -> {
+            cubeAccessWrapper.applySections();
+
+            // Exit early and don't waste time on empty sections.
+            if (areSectionsEmpty(cubeY, pos, ((NoiseAndSurfaceBuilderHelper) chunkAccess).getDelegateByIndex(0))) {
+                return chunkAccess;
+            }
+
+            generator.buildSurfaceAndBedrock(cubeWorldGenRegion, chunkAccess);
+
+            // Carvers
+            generator.applyCarvers(world.getSeed(), world.getBiomeManager(), cubeAccessWrapper, GenerationStep.Carving.AIR);
+            generator.applyCarvers(world.getSeed(), world.getBiomeManager(), cubeAccessWrapper, GenerationStep.Carving.LIQUID);
+            return chunkAccess;
+        });
     }
 
     private static boolean areSectionsEmpty(int cubeY, ChunkPos pos, IBigCube cube) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/server/MixinServerWorldLightManager.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/server/MixinServerWorldLightManager.java
@@ -6,7 +6,6 @@ import java.util.function.IntSupplier;
 import javax.annotation.Nullable;
 
 import com.mojang.datafixers.util.Pair;
-import io.github.opencubicchunks.cubicchunks.CubicChunks;
 import io.github.opencubicchunks.cubicchunks.chunk.IBigCube;
 import io.github.opencubicchunks.cubicchunks.chunk.IChunkManager;
 import io.github.opencubicchunks.cubicchunks.chunk.ticket.CubeTaskPriorityQueueSorter;
@@ -127,12 +126,8 @@ public abstract class MixinServerWorldLightManager extends MixinWorldLightManage
             super.enableLightSources(cubePos, true);
             if (!flagIn) {
                 icube.getCubeLightSources().forEach((blockPos) -> {
-                    //TODO: Figure out why some positions are null. Might have to do with the multithreading of the noise stage of world generation.
-                    if (blockPos == null) {
-                        CubicChunks.LOGGER.error("Block pos was null when attempting to calculate block light emission, skipping...");
-                    } else {
-                        super.onBlockEmissionIncrease(blockPos, icube.getLightEmission(blockPos));
-                    }
+                    assert blockPos != null;
+                    super.onBlockEmissionIncrease(blockPos, icube.getLightEmission(blockPos));
                 });
             }
 


### PR DESCRIPTION
Previously, all "cube section columns" (the 16x32x16 areas) were running simultaneously on different threads on the background executor.
This was due to both using `thenCombine` and also a result of `NoiseBasedChunkGenerator#fillFromNoise` running `supplyAsync`

The futures are now properly chained, and within one cube, only one "cube section column" is running at a time