### PR TITLE
-Don't read columns in section storage when updating. Read cubes instead.

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/storage/ISectionStorage.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/chunk/storage/ISectionStorage.java
@@ -2,14 +2,13 @@ package io.github.opencubicchunks.cubicchunks.chunk.storage;
 
 import io.github.opencubicchunks.cubicchunks.chunk.util.CubePos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.IOWorker;
 
 public interface ISectionStorage {
 
     void flush(CubePos cubePos);
 
-    void updateColumn(ChunkPos pos, CompoundTag tag);
+    void updateCube(CubePos pos, CompoundTag tag);
 
     IOWorker getIOWorker();
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkManager.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/chunk/MixinChunkManager.java
@@ -928,7 +928,9 @@ public abstract class MixinChunkManager implements IChunkManager, IChunkMapInter
                     boolean flag = cubeNBT.contains("Level", 10) && cubeNBT.getCompound("Level").contains("Status", 8);
                     if (flag) {
                         ChunkIoMainThreadTaskUtils.executeMain(() -> {
-                            if (poiNBT != null) ((ISectionStorage) this.poiManager).updateColumn(cubePos.asChunkPos(), poiNBT);
+                            if (poiNBT != null) {
+                                ((ISectionStorage) this.poiManager).updateCube(cubePos, poiNBT);
+                            }
                         });
                         return CubeSerializer.read(this.level, this.structureManager, poiManager, cubePos, cubeNBT);
                     }


### PR DESCRIPTION
-Locks server thread when reading the entire column