### PR TITLE
Fix wrong calculation of required amount of ExtendedBlockStorage's

### DIFF
--- a/CubicChunksAPI/src/main/java/io/github/opencubicchunks/cubicchunks/api/world/IMinMaxHeight.java
+++ b/CubicChunksAPI/src/main/java/io/github/opencubicchunks/cubicchunks/api/world/IMinMaxHeight.java
@@ -32,7 +32,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @MethodsReturnNonnullByDefault
 public interface IMinMaxHeight {
     /**
-     * Returns Y position of the bottom block in the world
+     * Returns Y position of the bottom block in the world,
+     * inclusive
      *
      * @return the bottom of the world
      */
@@ -42,6 +43,7 @@ public interface IMinMaxHeight {
 
     /**
      * Returns Y position of block above the top block in the world,
+     * exclusive
      *
      * @return the top of the world
      */

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/core/asm/mixin/core/common/MixinChunk_Cubes.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/core/asm/mixin/core/common/MixinChunk_Cubes.java
@@ -239,7 +239,9 @@ public abstract class MixinChunk_Cubes {
         }
         if (!((ICubicWorld) worldIn).isCubicWorld()) {
             IMinMaxHeight y = (IMinMaxHeight) worldIn;
-            return Coords.blockToCube(y.getMaxHeight()) - Coords.blockToCube(y.getMinHeight());
+            int firstInclusiveY = y.getMinHeight();
+            int lastInclusiveY = y.getMaxHeight() - 1;
+            return Coords.blockToCube(lastInclusiveY) - Coords.blockToCube(firstInclusiveY) + 1;
         }
         return sixteen;
     }


### PR DESCRIPTION
Case: World#getMinHeight == 1, World#getMaxHeight == 17, it required 2 length of `storageArrays`
but previous code of `modifySectionArrayLength` will give only 1 lenght.
This pr about support of cases when `getMaxHeight` returns not first block of next unused cube, which probably may be.